### PR TITLE
[Feat] 페르소나 문항 조회 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/member/controller/PersonasTestController.java
+++ b/src/main/java/com/umc/finly/domain/member/controller/PersonasTestController.java
@@ -1,0 +1,35 @@
+package com.umc.finly.domain.member.controller;
+
+import com.umc.finly.domain.member.dto.response.PersonasTestQuestionRes;
+import com.umc.finly.domain.member.service.PersonasTestService;
+import com.umc.finly.global.apiPayload.response.ApiResponse;
+import com.umc.finly.global.apiPayload.response.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/persona-test")
+public class PersonasTestController {
+
+    private final PersonasTestService personasTestService;
+
+    @GetMapping("/questions")
+    public ApiResponse<QuestionListResponse> getPersonasTestQuestions(){
+        List<PersonasTestQuestionRes> questions =
+                personasTestService.getPersonasTestQuestions();
+
+        return ApiResponse.onSuccess(
+                new QuestionListResponse(questions),
+                SuccessCode.OK
+        );
+    }
+
+    private record QuestionListResponse(
+            List<PersonasTestQuestionRes> questions
+    ){}
+}

--- a/src/main/java/com/umc/finly/domain/member/dto/response/PersonasTestOptionRes.java
+++ b/src/main/java/com/umc/finly/domain/member/dto/response/PersonasTestOptionRes.java
@@ -1,0 +1,21 @@
+package com.umc.finly.domain.member.dto.response;
+
+import com.umc.finly.domain.member.entity.PersonasTestOption;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter@Builder
+public class PersonasTestOptionRes {
+
+    private Long id;
+    private String choiceCode;
+    private String content;
+
+    public static PersonasTestOptionRes from(PersonasTestOption option){
+        return PersonasTestOptionRes.builder()
+                .id(option.getId())
+                .choiceCode(option.getChoiceCode().name())
+                .content(option.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/member/dto/response/PersonasTestOptionRes.java
+++ b/src/main/java/com/umc/finly/domain/member/dto/response/PersonasTestOptionRes.java
@@ -4,7 +4,8 @@ import com.umc.finly.domain.member.entity.PersonasTestOption;
 import lombok.Builder;
 import lombok.Getter;
 
-@Getter@Builder
+@Getter
+@Builder
 public class PersonasTestOptionRes {
 
     private Long id;

--- a/src/main/java/com/umc/finly/domain/member/dto/response/PersonasTestQuestionRes.java
+++ b/src/main/java/com/umc/finly/domain/member/dto/response/PersonasTestQuestionRes.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 
 import java.util.List;
 
-@Getter@Builder
+@Getter
+@Builder
 public class PersonasTestQuestionRes {
 
     private Long id;

--- a/src/main/java/com/umc/finly/domain/member/dto/response/PersonasTestQuestionRes.java
+++ b/src/main/java/com/umc/finly/domain/member/dto/response/PersonasTestQuestionRes.java
@@ -1,0 +1,28 @@
+package com.umc.finly.domain.member.dto.response;
+
+import com.umc.finly.domain.member.entity.PersonasTestQuestion;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter@Builder
+public class PersonasTestQuestionRes {
+
+    private Long id;
+    private String questionCode;
+    private String content;
+    private List<PersonasTestOptionRes> options;
+
+    public static PersonasTestQuestionRes of(
+            PersonasTestQuestion question,
+            List<PersonasTestOptionRes> options
+    ){
+        return PersonasTestQuestionRes.builder()
+                .id(question.getId())
+                .questionCode(question.getQuestionCode().name())
+                .content(question.getContent())
+                .options(options)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/member/entity/Personas.java
+++ b/src/main/java/com/umc/finly/domain/member/entity/Personas.java
@@ -1,0 +1,32 @@
+package com.umc.finly.domain.member.entity;
+
+import com.umc.finly.domain.member.enums.PersonaType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Table(name = "personas")
+public class Personas {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "persona_type",nullable = false, unique = true)
+    private PersonaType personaType;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, length = 1000)
+    private String description;
+
+    @Column(name = "icon_url")
+    private String iconUrl;
+
+}

--- a/src/main/java/com/umc/finly/domain/member/entity/PersonasTestOption.java
+++ b/src/main/java/com/umc/finly/domain/member/entity/PersonasTestOption.java
@@ -1,0 +1,31 @@
+package com.umc.finly.domain.member.entity;
+
+import com.umc.finly.domain.member.enums.ChoiceCode;
+import com.umc.finly.global.entity.CreatedBaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Table(name = "personas_test_option")
+public class PersonasTestOption extends CreatedBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    private PersonasTestQuestion question;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "choice_code", nullable = false)
+    private ChoiceCode choiceCode;
+
+    @Column(nullable = false, length = 300)
+    private String content;
+
+}

--- a/src/main/java/com/umc/finly/domain/member/entity/PersonasTestQuestion.java
+++ b/src/main/java/com/umc/finly/domain/member/entity/PersonasTestQuestion.java
@@ -1,0 +1,26 @@
+package com.umc.finly.domain.member.entity;
+
+import com.umc.finly.domain.member.enums.QuestionCode;
+import com.umc.finly.global.entity.CreatedBaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter@Builder
+@Table(name = "personas_test_question")
+public class PersonasTestQuestion extends CreatedBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "question_code", nullable = false, unique = true)
+    private QuestionCode questionCode;
+
+    @Column(nullable = false, length = 500)
+    private String content;
+
+}

--- a/src/main/java/com/umc/finly/domain/member/entity/PersonasTestQuestion.java
+++ b/src/main/java/com/umc/finly/domain/member/entity/PersonasTestQuestion.java
@@ -8,7 +8,8 @@ import lombok.*;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Getter@Builder
+@Getter
+@Builder
 @Table(name = "personas_test_question")
 public class PersonasTestQuestion extends CreatedBaseEntity {
 

--- a/src/main/java/com/umc/finly/domain/member/entity/mapping/MembersPersonasOption.java
+++ b/src/main/java/com/umc/finly/domain/member/entity/mapping/MembersPersonasOption.java
@@ -1,0 +1,38 @@
+package com.umc.finly.domain.member.entity.mapping;
+
+import com.umc.finly.domain.member.entity.PersonasTestOption;
+import com.umc.finly.domain.member.entity.PersonasTestQuestion;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Table(
+        name = "members_personas_option",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_member_question",
+                        columnNames = {"mem_id", "question_id"}
+                )
+        }
+)
+public class MembersPersonasOption {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "mem_id", nullable = false)
+    private Long memberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    private PersonasTestQuestion question;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "option_id", nullable = false)
+    private PersonasTestOption option;
+}

--- a/src/main/java/com/umc/finly/domain/member/entity/mapping/MembersPersonasResult.java
+++ b/src/main/java/com/umc/finly/domain/member/entity/mapping/MembersPersonasResult.java
@@ -1,0 +1,34 @@
+package com.umc.finly.domain.member.entity.mapping;
+
+import com.umc.finly.domain.member.entity.Personas;
+import com.umc.finly.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+@Builder
+@Table(
+        name = "members_personas_result",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_member_persona",
+                        columnNames = {"mem_id"}
+                )
+        }
+)
+public class MembersPersonasResult extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "mem_id", nullable = false)
+    private Long memberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "persona_id", nullable = false)
+    private Personas persona;
+}

--- a/src/main/java/com/umc/finly/domain/member/enums/ChoiceCode.java
+++ b/src/main/java/com/umc/finly/domain/member/enums/ChoiceCode.java
@@ -1,0 +1,5 @@
+package com.umc.finly.domain.member.enums;
+
+public enum ChoiceCode {
+    A, B, C
+}

--- a/src/main/java/com/umc/finly/domain/member/enums/PersonaType.java
+++ b/src/main/java/com/umc/finly/domain/member/enums/PersonaType.java
@@ -1,0 +1,19 @@
+package com.umc.finly.domain.member.enums;
+
+public enum PersonaType {
+
+    WORRIED_DEER("걱정 많은 사슴"),
+    CAUTIOUS_TURTLE("신중한 거북이"),
+    SHARP_EAGLE("날카로운 독수리"),
+    FIERY_LION("불타는 사자");
+
+    private final String displayName;
+
+    PersonaType(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/src/main/java/com/umc/finly/domain/member/enums/QuestionCode.java
+++ b/src/main/java/com/umc/finly/domain/member/enums/QuestionCode.java
@@ -1,0 +1,5 @@
+package com.umc.finly.domain.member.enums;
+
+public enum QuestionCode {
+    Q1, Q2, Q3
+}

--- a/src/main/java/com/umc/finly/domain/member/repository/PersonasTestOptionRepository.java
+++ b/src/main/java/com/umc/finly/domain/member/repository/PersonasTestOptionRepository.java
@@ -1,0 +1,12 @@
+package com.umc.finly.domain.member.repository;
+
+import com.umc.finly.domain.member.entity.PersonasTestOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PersonasTestOptionRepository
+        extends JpaRepository<PersonasTestOption, Long> {
+
+    List<PersonasTestOption> findByQuestionIdOrderByChoiceCodeAsc(Long questionId);
+}

--- a/src/main/java/com/umc/finly/domain/member/repository/PersonasTestQuestionRepository.java
+++ b/src/main/java/com/umc/finly/domain/member/repository/PersonasTestQuestionRepository.java
@@ -1,0 +1,12 @@
+package com.umc.finly.domain.member.repository;
+
+import com.umc.finly.domain.member.entity.PersonasTestQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PersonasTestQuestionRepository
+        extends JpaRepository<PersonasTestQuestion, Long> {
+
+    List<PersonasTestQuestion> findAllByOrderByQuestionCodeAsc();
+}

--- a/src/main/java/com/umc/finly/domain/member/service/PersonasTestService.java
+++ b/src/main/java/com/umc/finly/domain/member/service/PersonasTestService.java
@@ -1,0 +1,9 @@
+package com.umc.finly.domain.member.service;
+
+import com.umc.finly.domain.member.dto.response.PersonasTestQuestionRes;
+
+import java.util.List;
+
+public interface PersonasTestService {
+    List<PersonasTestQuestionRes> getPersonasTestQuestions();
+}

--- a/src/main/java/com/umc/finly/domain/member/service/PersonasTestServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/member/service/PersonasTestServiceImpl.java
@@ -1,0 +1,40 @@
+package com.umc.finly.domain.member.service;
+
+import com.umc.finly.domain.member.dto.response.PersonasTestOptionRes;
+import com.umc.finly.domain.member.dto.response.PersonasTestQuestionRes;
+import com.umc.finly.domain.member.entity.PersonasTestQuestion;
+import com.umc.finly.domain.member.repository.PersonasTestOptionRepository;
+import com.umc.finly.domain.member.repository.PersonasTestQuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PersonasTestServiceImpl implements PersonasTestService{
+
+    private final PersonasTestQuestionRepository questionRepository;
+    private final PersonasTestOptionRepository optionRepository;
+
+    @Override
+    public List<PersonasTestQuestionRes> getPersonasTestQuestions(){
+
+        List<PersonasTestQuestion> questions =
+                 questionRepository.findAllByOrderByQuestionCodeAsc();
+
+        return questions.stream()
+                .map(question->{
+                    List<PersonasTestOptionRes> options =
+                            optionRepository
+                                    .findByQuestionIdOrderByChoiceCodeAsc(question.getId())
+                                    .stream()
+                                    .map(PersonasTestOptionRes::from)
+                                    .toList();
+                    return PersonasTestQuestionRes.of(question, options);
+                })
+                .toList();
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #3 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
1. Personas 관련 엔티티 생성
2. Repository/DTO/Service/Controller 생성 및 구현


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
<img width="1389" height="506" alt="스크린샷 2026-01-23 오후 9 55 05" src="https://github.com/user-attachments/assets/a95a93ca-43cd-47b5-af24-b8b2ab948dc8" />
<img width="2120" height="1000" alt="image" src="https://github.com/user-attachments/assets/eefc583c-96ae-43ff-ade2-95bcf14924de" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.
api 명세서에 persona 쪽 member 쪽에 속해있어서 따로 파일 안파고, member domain에서 작업했습니다....
제 로컬 DB에 페르소나 질문이랑 답 저장해놓고, 조회 api 구현하였습니다. 
한 번 보시고 수정할 거 있다면 바로 말씀해주세요. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 성향 테스트 기능 추가 — 객관식 질문과 선택지를 통해 사용자의 성향을 진단할 수 있습니다.
  * 성향 테스트 조회 API 제공 — 모든 질문과 보기 정보를 구조화된 응답으로 조회할 수 있습니다.
  * 테스트 결과·선택지 저장 지원 — 사용자의 선택 및 진단 결과를 저장하고 개인별 성향을 관리할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->