### PR TITLE
[Feat] 기록 생성 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ out/
 
 ### 초기 DB SQL ###
 /src/main/resources/db/*.sql
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ bin/
 *.iws
 *.iml
 *.ipr
+nul
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/

--- a/src/main/java/com/umc/finly/domain/record/controller/RecordController.java
+++ b/src/main/java/com/umc/finly/domain/record/controller/RecordController.java
@@ -1,0 +1,30 @@
+package com.umc.finly.domain.record.controller;
+
+import com.umc.finly.domain.record.dto.RecordCreateReq;
+import com.umc.finly.domain.record.dto.RecordCreateRes;
+import com.umc.finly.domain.record.service.RecordService;
+import com.umc.finly.global.apiPayload.response.ApiResponse;
+import com.umc.finly.global.apiPayload.response.SuccessCode;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/records")
+public class RecordController {
+
+    private final RecordService recordService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<RecordCreateRes>> createRecord(
+            @RequestHeader("X-User-Id") Long userId,
+            @Valid @RequestBody RecordCreateReq request
+    ) {
+        RecordCreateRes result = recordService.createRecord(userId, request);
+
+        ApiResponse<RecordCreateRes> body = ApiResponse.onSuccess(result, SuccessCode.CREATED);
+        return ResponseEntity.status(SuccessCode.CREATED.getHttpStatus()).body(body);
+    }
+}

--- a/src/main/java/com/umc/finly/domain/record/controller/RecordController.java
+++ b/src/main/java/com/umc/finly/domain/record/controller/RecordController.java
@@ -5,9 +5,10 @@ import com.umc.finly.domain.record.dto.RecordCreateRes;
 import com.umc.finly.domain.record.service.RecordService;
 import com.umc.finly.global.apiPayload.response.ApiResponse;
 import com.umc.finly.global.apiPayload.response.SuccessCode;
+import com.umc.finly.global.config.security.AuthPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -18,13 +19,11 @@ public class RecordController {
     private final RecordService recordService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<RecordCreateRes>> createRecord(
-            @RequestHeader("X-User-Id") Long userId,
+    public ApiResponse<RecordCreateRes> createRecord(
+            @AuthenticationPrincipal AuthPrincipal principal,
             @Valid @RequestBody RecordCreateReq request
     ) {
-        RecordCreateRes result = recordService.createRecord(userId, request);
-
-        ApiResponse<RecordCreateRes> body = ApiResponse.onSuccess(result, SuccessCode.CREATED);
-        return ResponseEntity.status(SuccessCode.CREATED.getHttpStatus()).body(body);
+        RecordCreateRes result = recordService.createRecord(principal.getMemberId(), request);
+        return ApiResponse.onSuccess(result, SuccessCode.CREATED);
     }
 }

--- a/src/main/java/com/umc/finly/domain/record/dto/RecordCreateReq.java
+++ b/src/main/java/com/umc/finly/domain/record/dto/RecordCreateReq.java
@@ -1,0 +1,44 @@
+package com.umc.finly.domain.record.dto;
+
+import com.umc.finly.domain.record.entity.EmotionCode;
+import com.umc.finly.domain.record.entity.TradeAction;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class RecordCreateReq {
+
+    @NotBlank(message = "clientRequestId는 필수입니다.")
+    private String clientRequestId;
+
+    @NotNull(message = "recordDate는 필수입니다.")
+    private LocalDate recordDate;
+
+    @NotNull(message = "stockId는 필수입니다.")
+    private Long stockId;
+
+    @NotNull(message = "tradeAction은 필수입니다.")
+    private TradeAction tradeAction;
+
+    @DecimalMin(value = "0.0", inclusive = false, message = "unitPrice는 0보다 커야 합니다.")
+    private BigDecimal unitPrice;
+
+    @DecimalMin(value = "0.0", inclusive = false, message = "quantity는 0보다 커야 합니다.")
+    private BigDecimal quantity;
+
+    @NotNull(message = "emotionCode는 필수입니다.")
+    private EmotionCode emotionCode;
+
+    @NotNull(message = "emotionIntensity는 필수입니다.")
+    @Min(value = 1, message = "emotionIntensity는 1 이상이어야 합니다.")
+    @Max(value = 7, message = "emotionIntensity는 7 이하이어야 합니다.")
+    private Integer emotionIntensity;
+
+    @Size(max = 200, message = "memo는 최대 200자까지 입력 가능합니다.")
+    private String memo;
+}

--- a/src/main/java/com/umc/finly/domain/record/dto/RecordCreateRes.java
+++ b/src/main/java/com/umc/finly/domain/record/dto/RecordCreateRes.java
@@ -1,0 +1,46 @@
+package com.umc.finly.domain.record.dto;
+
+import com.umc.finly.domain.record.entity.*;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class RecordCreateRes {
+
+    private Long recordId;
+    private LocalDate recordDate;
+    private LocalDateTime recordedAt;
+    private Session session;
+    private TradeAction tradeAction;
+    private Long stockId;
+    private EmotionCode emotionCode;
+    private Integer emotionIntensity;
+    private String memo;
+    private FeedbackInfo feedback;
+
+    @Getter
+    @Builder
+    public static class FeedbackInfo {
+        private Long feedbackId;
+        private String status;
+    }
+
+    public static RecordCreateRes from(RecordEntry entry) {
+        return RecordCreateRes.builder()
+                .recordId(entry.getId())
+                .recordDate(entry.getRecordDate())
+                .recordedAt(entry.getCreatedAt())
+                .session(entry.getSession())
+                .tradeAction(entry.getTradeAction())
+                .stockId(entry.getStockId())
+                .emotionCode(entry.getEmotionCode())
+                .emotionIntensity(entry.getEmotionIntensity())
+                .memo(entry.getMemo())
+                .feedback(null)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/record/entity/EmotionCode.java
+++ b/src/main/java/com/umc/finly/domain/record/entity/EmotionCode.java
@@ -1,0 +1,9 @@
+package com.umc.finly.domain.record.entity;
+
+public enum EmotionCode {
+    CALM,
+    ANXIETY,
+    REGRET,
+    GREED,
+    CONFIDENCE
+}

--- a/src/main/java/com/umc/finly/domain/record/entity/RecordEntry.java
+++ b/src/main/java/com/umc/finly/domain/record/entity/RecordEntry.java
@@ -1,0 +1,58 @@
+package com.umc.finly.domain.record.entity;
+
+import com.umc.finly.global.entity.CreatedUpdatedDeletedBaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "record_entry")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class RecordEntry extends CreatedUpdatedDeletedBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "client_request_id", nullable = false, unique = true)
+    private String clientRequestId;
+
+    @Column(name = "record_date", nullable = false)
+    private LocalDate recordDate;
+
+    @Column(name = "stock_id", nullable = false)
+    private Long stockId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "trade_action", nullable = false)
+    private TradeAction tradeAction;
+
+    @Column(name = "unit_price", precision = 19, scale = 4)
+    private BigDecimal unitPrice;
+
+    @Column(name = "quantity", precision = 19, scale = 4)
+    private BigDecimal quantity;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "emotion_code", nullable = false)
+    private EmotionCode emotionCode;
+
+    @Column(name = "emotion_intensity", nullable = false)
+    private Integer emotionIntensity;
+
+    @Column(name = "memo", length = 200)
+    private String memo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "session", nullable = false)
+    private Session session;
+}

--- a/src/main/java/com/umc/finly/domain/record/entity/Session.java
+++ b/src/main/java/com/umc/finly/domain/record/entity/Session.java
@@ -1,0 +1,20 @@
+package com.umc.finly.domain.record.entity;
+
+import java.time.LocalTime;
+
+public enum Session {
+    MORNING,    // 06:00 ~ 11:59
+    AFTERNOON,  // 12:00 ~ 17:59
+    EVENING;    // 18:00 ~ 05:59
+
+    public static Session fromTime(LocalTime time) {
+        int hour = time.getHour();
+        if (hour >= 6 && hour < 12) {
+            return MORNING;
+        } else if (hour >= 12 && hour < 18) {
+            return AFTERNOON;
+        } else {
+            return EVENING;
+        }
+    }
+}

--- a/src/main/java/com/umc/finly/domain/record/entity/Session.java
+++ b/src/main/java/com/umc/finly/domain/record/entity/Session.java
@@ -3,18 +3,24 @@ package com.umc.finly.domain.record.entity;
 import java.time.LocalTime;
 
 public enum Session {
-    MORNING,    // 06:00 ~ 11:59
-    AFTERNOON,  // 12:00 ~ 17:59
-    EVENING;    // 18:00 ~ 05:59
+    PRE_MARKET,   // 00:00 ~ 09:00 (장전 브리핑 - 예측의 시간)
+    MORNING,      // 09:00 ~ 12:00 (오전 - 변동성의 시간)
+    AFTERNOON,    // 12:00 ~ 15:30 (오후 - 이성의 시간)
+    POST_MARKET;  // 15:30 ~ 00:00 (장후 복기 - 정리의 시간)
+
+    private static final LocalTime MARKET_OPEN = LocalTime.of(9, 0);
+    private static final LocalTime NOON = LocalTime.of(12, 0);
+    private static final LocalTime MARKET_CLOSE = LocalTime.of(15, 30);
 
     public static Session fromTime(LocalTime time) {
-        int hour = time.getHour();
-        if (hour >= 6 && hour < 12) {
+        if (time.isBefore(MARKET_OPEN)) {
+            return PRE_MARKET;
+        } else if (time.isBefore(NOON)) {
             return MORNING;
-        } else if (hour >= 12 && hour < 18) {
+        } else if (time.isBefore(MARKET_CLOSE)) {
             return AFTERNOON;
         } else {
-            return EVENING;
+            return POST_MARKET;
         }
     }
 }

--- a/src/main/java/com/umc/finly/domain/record/entity/TradeAction.java
+++ b/src/main/java/com/umc/finly/domain/record/entity/TradeAction.java
@@ -1,0 +1,7 @@
+package com.umc.finly.domain.record.entity;
+
+public enum TradeAction {
+    BUY,
+    SELL,
+    WATCH
+}

--- a/src/main/java/com/umc/finly/domain/record/repository/RecordEntryRepository.java
+++ b/src/main/java/com/umc/finly/domain/record/repository/RecordEntryRepository.java
@@ -1,0 +1,8 @@
+package com.umc.finly.domain.record.repository;
+
+import com.umc.finly.domain.record.entity.RecordEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecordEntryRepository extends JpaRepository<RecordEntry, Long> {
+    boolean existsByClientRequestId(String clientRequestId);
+}

--- a/src/main/java/com/umc/finly/domain/record/service/RecordService.java
+++ b/src/main/java/com/umc/finly/domain/record/service/RecordService.java
@@ -1,0 +1,8 @@
+package com.umc.finly.domain.record.service;
+
+import com.umc.finly.domain.record.dto.RecordCreateReq;
+import com.umc.finly.domain.record.dto.RecordCreateRes;
+
+public interface RecordService {
+    RecordCreateRes createRecord(Long userId, RecordCreateReq request);
+}

--- a/src/main/java/com/umc/finly/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/record/service/RecordServiceImpl.java
@@ -1,0 +1,62 @@
+package com.umc.finly.domain.record.service;
+
+import com.umc.finly.domain.record.dto.RecordCreateReq;
+import com.umc.finly.domain.record.dto.RecordCreateRes;
+import com.umc.finly.domain.record.entity.RecordEntry;
+import com.umc.finly.domain.record.entity.Session;
+import com.umc.finly.domain.record.entity.TradeAction;
+import com.umc.finly.domain.record.repository.RecordEntryRepository;
+import com.umc.finly.global.apiPayload.exception.CustomException;
+import com.umc.finly.global.apiPayload.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecordServiceImpl implements RecordService {
+
+    private final RecordEntryRepository recordEntryRepository;
+
+    @Override
+    @Transactional
+    public RecordCreateRes createRecord(Long userId, RecordCreateReq request) {
+        // 1. clientRequestId 중복 체크
+        if (recordEntryRepository.existsByClientRequestId(request.getClientRequestId())) {
+            throw new CustomException(ErrorCode.RECORD_DUPLICATE_SUBMISSION);
+        }
+
+        // 2. tradeAction이 BUY/SELL이면 unitPrice, quantity 필수 검증
+        if (request.getTradeAction() == TradeAction.BUY || request.getTradeAction() == TradeAction.SELL) {
+            if (request.getUnitPrice() == null || request.getQuantity() == null) {
+                throw new CustomException(ErrorCode.RECORD_INVALID_REQUEST);
+            }
+        }
+
+        // 3. Session 자동 계산 (현재 시간 기반)
+        Session session = Session.fromTime(LocalTime.now());
+
+        // 4. RecordEntry 엔티티 생성 및 저장
+        RecordEntry entry = RecordEntry.builder()
+                .userId(userId)
+                .clientRequestId(request.getClientRequestId())
+                .recordDate(request.getRecordDate())
+                .stockId(request.getStockId())
+                .tradeAction(request.getTradeAction())
+                .unitPrice(request.getUnitPrice())
+                .quantity(request.getQuantity())
+                .emotionCode(request.getEmotionCode())
+                .emotionIntensity(request.getEmotionIntensity())
+                .memo(request.getMemo())
+                .session(session)
+                .build();
+
+        RecordEntry savedEntry = recordEntryRepository.save(entry);
+
+        // 5. 응답 DTO 반환
+        return RecordCreateRes.from(savedEntry);
+    }
+}

--- a/src/main/java/com/umc/finly/global/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/umc/finly/global/apiPayload/exception/ExceptionAdvice.java
@@ -68,7 +68,8 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Object> handleUnknownException(Exception e, WebRequest request) {
         log.error("Unhandled exception", e); // printStackTrace() 지양
-        ApiResponse<Object> body = ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR, null); // 내부 메시지 노출 X
+        // TODO: 배포 전 null로 변경 필요 (현재는 디버깅용)
+        ApiResponse<Object> body = ApiResponse.onFailure(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
         return handleExceptionInternal(e, body, new HttpHeaders(),
                 ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus(), request);
     }

--- a/src/main/java/com/umc/finly/global/apiPayload/response/ErrorCode.java
+++ b/src/main/java/com/umc/finly/global/apiPayload/response/ErrorCode.java
@@ -21,6 +21,13 @@ public enum ErrorCode implements BaseCode {
     // AUTH 4xx
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH409", "이미 가입된 이메일입니다."),
 
+    // RECORD 4xx
+    RECORD_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "RECORD400", "필수값 또는 형식 오류입니다."),
+    RECORD_DUPLICATE_SUBMISSION(HttpStatus.CONFLICT, "RECORD409", "중복 제출된 요청입니다."),
+
+    // MARKET 4xx
+    MARKET_STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "MARKET404", "종목을 찾을 수 없습니다."),
+
     // COMMON 5xx (서버 오류)
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 내부 오류가 발생했습니다."),
     BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "COMMON502", "잘못된 게이트웨이 오류가 발생했습니다."),

--- a/src/main/java/com/umc/finly/global/config/DataInitializer.java
+++ b/src/main/java/com/umc/finly/global/config/DataInitializer.java
@@ -1,0 +1,176 @@
+package com.umc.finly.global.config;
+
+import com.umc.finly.domain.auth.entity.Term;
+import com.umc.finly.domain.auth.enums.TermType;
+import com.umc.finly.domain.auth.repository.TermRepository;
+import com.umc.finly.domain.member.entity.Persona;
+import com.umc.finly.domain.member.entity.PersonaTestOption;
+import com.umc.finly.domain.member.entity.PersonaTestQuestion;
+import com.umc.finly.domain.member.enums.ChoiceCode;
+import com.umc.finly.domain.member.enums.PersonaType;
+import com.umc.finly.domain.member.enums.QuestionCode;
+import com.umc.finly.domain.member.repository.PersonaRepository;
+import com.umc.finly.domain.member.repository.PersonaTestOptionsRepository;
+import com.umc.finly.domain.member.repository.PersonaTestQuestionsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DataInitializer implements ApplicationRunner {
+
+    private final TermRepository termRepository;
+    private final PersonaTestQuestionsRepository questionRepository;
+    private final PersonaTestOptionsRepository optionRepository;
+    private final PersonaRepository personaRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        initTerms();
+        initPersonaTestQuestions();
+        initPersonas();
+    }
+
+    private void initTerms() {
+        if (termRepository.count() > 0) {
+            log.info("Terms 데이터가 이미 존재합니다. 초기화를 건너뜁니다.");
+            return;
+        }
+
+        Term termsAgreed = Term.builder()
+                .title("(필수) 이용약관 동의")
+                .termType(TermType.TERMS_AGREED)
+                .build();
+
+        Term privacyAgreed = Term.builder()
+                .title("(필수) 개인정보처리방침 동의")
+                .termType(TermType.PRIVACY_AGREED)
+                .build();
+
+        Term marketingAgreed = Term.builder()
+                .title("(선택) 마케팅 정보 수신 동의")
+                .termType(TermType.MARKETING_AGREED)
+                .build();
+
+        termRepository.save(termsAgreed);
+        termRepository.save(privacyAgreed);
+        termRepository.save(marketingAgreed);
+
+        log.info("Terms 초기 데이터 3건이 생성되었습니다.");
+    }
+
+    private void initPersonaTestQuestions() {
+        if (questionRepository.count() > 0) {
+            log.info("PersonaTestQuestions 데이터가 이미 존재합니다. 초기화를 건너뜁니다.");
+            return;
+        }
+
+        // Q1: 투자 경험 질문
+        PersonaTestQuestion q1 = questionRepository.save(PersonaTestQuestion.builder()
+                .questionCode(QuestionCode.Q1)
+                .content("주식 투자 경험이 있으신가요?")
+                .build());
+
+        // Q2: 투자 목적 질문
+        PersonaTestQuestion q2 = questionRepository.save(PersonaTestQuestion.builder()
+                .questionCode(QuestionCode.Q2)
+                .content("투자의 주된 목적은 무엇인가요?")
+                .build());
+
+        // Q3: 리스크 성향 질문
+        PersonaTestQuestion q3 = questionRepository.save(PersonaTestQuestion.builder()
+                .questionCode(QuestionCode.Q3)
+                .content("투자 시 리스크를 어느 정도 감수할 수 있나요?")
+                .build());
+
+        // Q1 선택지 (id: 1, 2, 3)
+        optionRepository.save(PersonaTestOption.builder()
+                .question(q1)
+                .choiceCode(ChoiceCode.A)
+                .content("네, 경험이 있습니다")
+                .build());
+        optionRepository.save(PersonaTestOption.builder()
+                .question(q1)
+                .choiceCode(ChoiceCode.B)
+                .content("아니요, 처음입니다")
+                .build());
+        optionRepository.save(PersonaTestOption.builder()
+                .question(q1)
+                .choiceCode(ChoiceCode.C)
+                .content("조금 해봤습니다")
+                .build());
+
+        // Q2 선택지 (id: 4, 5, 6)
+        optionRepository.save(PersonaTestOption.builder()
+                .question(q2)
+                .choiceCode(ChoiceCode.A)
+                .content("안정적인 자산 증식")
+                .build());
+        optionRepository.save(PersonaTestOption.builder()
+                .question(q2)
+                .choiceCode(ChoiceCode.B)
+                .content("단기 수익 실현")
+                .build());
+        optionRepository.save(PersonaTestOption.builder()
+                .question(q2)
+                .choiceCode(ChoiceCode.C)
+                .content("장기적인 목돈 마련")
+                .build());
+
+        // Q3 선택지 (id: 7, 8, 9)
+        optionRepository.save(PersonaTestOption.builder()
+                .question(q3)
+                .choiceCode(ChoiceCode.A)
+                .content("리스크를 최소화하고 싶습니다")
+                .build());
+        optionRepository.save(PersonaTestOption.builder()
+                .question(q3)
+                .choiceCode(ChoiceCode.B)
+                .content("적당한 리스크는 감수합니다")
+                .build());
+        optionRepository.save(PersonaTestOption.builder()
+                .question(q3)
+                .choiceCode(ChoiceCode.C)
+                .content("높은 수익을 위해 리스크를 감수합니다")
+                .build());
+
+        log.info("PersonaTestQuestions 3건, PersonaTestOptions 9건이 생성되었습니다.");
+    }
+
+    private void initPersonas() {
+        if (personaRepository.count() > 0) {
+            log.info("Personas 데이터가 이미 존재합니다. 초기화를 건너뜁니다.");
+            return;
+        }
+
+        personaRepository.save(Persona.builder()
+                .personaType(PersonaType.WORRIED_DEER)
+                .title("걱정 많은 사슴")
+                .description("투자에 대한 걱정이 많지만, 차근차근 배워나가고 싶은 타입입니다.")
+                .build());
+
+        personaRepository.save(Persona.builder()
+                .personaType(PersonaType.CAUTIOUS_TURTLE)
+                .title("신중한 거북이")
+                .description("안정적인 투자를 선호하며, 리스크를 최소화하는 타입입니다.")
+                .build());
+
+        personaRepository.save(Persona.builder()
+                .personaType(PersonaType.SHARP_EAGLE)
+                .title("날카로운 독수리")
+                .description("높은 수익을 위해 과감하게 투자하는 공격적인 타입입니다.")
+                .build());
+
+        personaRepository.save(Persona.builder()
+                .personaType(PersonaType.FIERY_LION)
+                .title("불타는 사자")
+                .description("적극적이고 열정적으로 투자에 임하는 타입입니다.")
+                .build());
+
+        log.info("Personas 초기 데이터 4건이 생성되었습니다.");
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요. 

closes #11 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

POST /api/records
기록 생성(제출)
- 날짜 선택
- 종목명 검색
- 감정 선택 + 레벨 선택
- 메모 작성

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

[확인하러 가기](https://www.notion.so/_-2f2b7acc900f80c5b8e4df72325693d2?source=copy_link)
- 기록 생성 API (POST /api/records)

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 거래 기록 제출 API 추가 — 매매/관찰, 감정(코드·강도), 가격·수량, 메모 입력으로 기록 생성 가능하며 응답에 기록 ID·상태·피드백 포함.
  * 기록 시점에 따라 세션(장전/오전/오후/장후) 자동 판정.

* **버그 수정 / 검증**
  * 필수 항목 검증 강화 및 클라이언트 중복 제출 차단.

* **오류 처리**
  * 유효성·중복·종목 미발견 관련 오류 코드 추가.

* **초기 데이터**
  * 약관, 페르소나 테스트 문항/선택지 및 페르소나 기본값 초기화 추가.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->