### PR TITLE
[Feat] 종목 분석 조회 API 현재가 조회 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,9 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.13'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	compileOnly 'org.projectlombok:lombok'
+    // TTL 설정 및 캐시 저장 개수 제한을 위한 Caffeine Cache 사용
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+    compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'

--- a/src/main/java/com/umc/finly/domain/analysis/controller/StockAnalysisController.java
+++ b/src/main/java/com/umc/finly/domain/analysis/controller/StockAnalysisController.java
@@ -1,0 +1,24 @@
+package com.umc.finly.domain.analysis.controller;
+
+import com.umc.finly.domain.analysis.dto.response.StockSummaryRes;
+import com.umc.finly.domain.analysis.service.StockAnalysisService;
+import com.umc.finly.global.apiPayload.response.ApiResponse;
+import com.umc.finly.global.apiPayload.response.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/analysis/stocks")
+public class StockAnalysisController {
+    private final StockAnalysisService stockAnalysisService;
+
+    @GetMapping("/{stockId}/summary")
+    public ApiResponse<StockSummaryRes> getStockSummary(
+            @PathVariable String stockId
+    ) {
+        StockSummaryRes result = stockAnalysisService.getStockSummary(stockId);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/dto/response/StockSummaryRes.java
+++ b/src/main/java/com/umc/finly/domain/analysis/dto/response/StockSummaryRes.java
@@ -1,0 +1,19 @@
+package com.umc.finly.domain.analysis.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StockSummaryRes {
+    private Integer averageBuyPrice;
+    private Integer currentPrice; // currentPrice 응답 필드만 우선 연결
+    private Integer totalBuyCount;
+    private Integer maxHoldingDays;
+
+    public static StockSummaryRes currentPriceSummary(Integer currentPrice) {
+        return StockSummaryRes.builder()
+                .currentPrice(currentPrice)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/exception/code/AnalysisErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/analysis/exception/code/AnalysisErrorCode.java
@@ -1,0 +1,31 @@
+package com.umc.finly.domain.analysis.exception.code;
+
+import com.umc.finly.global.apiPayload.response.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AnalysisErrorCode implements BaseCode {
+    // 주식 데이터 탭
+    STOCK_CURRENT_PRICE_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "ANALYSIS_STOCK_CURRENT_PRICE_NOT_FOUND",
+            "존재하지 않는 종목입니다."
+    ),
+    STOCK_CURRENT_PRICE_API_FAILED(
+            HttpStatus.BAD_GATEWAY,
+            "ANALYSIS_STOCK_CURRENT_PRICE_API_FAILED",
+            "주식 현재가 조회 중 외부 API 오류가 발생했습니다."
+    ),
+    STOCK_CURRENT_PRICE_RESPONSE_INVALID(
+            HttpStatus.BAD_GATEWAY,
+            "ANALYSIS_STOCK_CURRENT_PRICE_RESPONSE_INVALID",
+            "주식 현재가 응답 형식이 올바르지 않습니다."
+    );
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/finly/domain/analysis/infra/NaverStockPriceProvider.java
+++ b/src/main/java/com/umc/finly/domain/analysis/infra/NaverStockPriceProvider.java
@@ -14,7 +14,7 @@ import org.springframework.web.client.RestClient;
 public class NaverStockPriceProvider implements StockPriceProvider {
     private static final String NAVER_API_URL = "https://polling.finance.naver.com/api/realtime/domestic/stock/%s";
     private final ObjectMapper objectMapper; // JSON 문자열을 자바 객체로 변환해주는 객체
-    private final RestClient restClient = RestClient.create(); // 외부 HTTP API를 호출하는 클라이언트
+    private final RestClient restClient; // 외부 HTTP API를 호출하는 클라이언트
 
     @Override
     public Integer getCurrentPrice(String stockCode) {
@@ -51,7 +51,7 @@ public class NaverStockPriceProvider implements StockPriceProvider {
         } catch (CustomException e) {
             throw e;
         } catch (Exception e) {
-            throw new CustomException(ErrorCode.BAD_GATEWAY, "네이버 주식 API 처리 중 오류가 발생했습니다: " + e.getMessage());
+            throw new CustomException(ErrorCode.BAD_GATEWAY, "네이버 주식 API 처리 중 오류가 발생했습니다: " + e);
         }
     }
 }

--- a/src/main/java/com/umc/finly/domain/analysis/infra/NaverStockPriceProvider.java
+++ b/src/main/java/com/umc/finly/domain/analysis/infra/NaverStockPriceProvider.java
@@ -1,0 +1,57 @@
+package com.umc.finly.domain.analysis.infra;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.finly.global.apiPayload.exception.CustomException;
+import com.umc.finly.global.apiPayload.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+// 네이버 금융 API를 이용해 국내 주식의 현재가를 조회
+@Component
+@RequiredArgsConstructor
+public class NaverStockPriceProvider implements StockPriceProvider {
+    private static final String NAVER_API_URL = "https://polling.finance.naver.com/api/realtime/domestic/stock/%s";
+    private final ObjectMapper objectMapper; // JSON 문자열을 자바 객체로 변환해주는 객체
+    private final RestClient restClient = RestClient.create(); // 외부 HTTP API를 호출하는 클라이언트
+
+    @Override
+    public Integer getCurrentPrice(String stockCode) {
+        String url = String.format(NAVER_API_URL, stockCode);
+
+        try {
+            String response = restClient.get()
+                    .uri(url)
+                    .header("User-Agent",
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36")
+                    .header("Accept", "application/json")
+                    .retrieve() // HTTP 요청 전송
+                    .body(String.class); // HTTP 응답 중 Body 부분만 꺼내서 String 타입으로 변환
+
+            JsonNode root = objectMapper.readTree(response);
+            JsonNode stockSnapshots = root.get("datas");
+
+            if (stockSnapshots == null || !stockSnapshots.isArray()) {
+                throw new CustomException(ErrorCode.BAD_GATEWAY, "네이버 주식 API 응답에 주식 데이터가 없습니다.");
+            }
+
+            if (stockSnapshots.isEmpty()) {
+                throw new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 종목 코드입니다.");
+            }
+
+            JsonNode stock = stockSnapshots.get(0);
+            JsonNode closePriceRaw = stock.get("closePriceRaw");
+
+            if (closePriceRaw == null) {
+                throw new CustomException(ErrorCode.BAD_GATEWAY, "closePriceRaw 데이터가 없습니다.");
+            }
+
+            return closePriceRaw.asInt();
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.BAD_GATEWAY, "네이버 주식 API 처리 중 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/infra/NaverStockPriceProvider.java
+++ b/src/main/java/com/umc/finly/domain/analysis/infra/NaverStockPriceProvider.java
@@ -2,8 +2,8 @@ package com.umc.finly.domain.analysis.infra;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.finly.domain.analysis.exception.code.AnalysisErrorCode;
 import com.umc.finly.global.apiPayload.exception.CustomException;
-import com.umc.finly.global.apiPayload.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -32,26 +32,26 @@ public class NaverStockPriceProvider implements StockPriceProvider {
             JsonNode root = objectMapper.readTree(response);
             JsonNode stockSnapshots = root.get("datas");
 
-            if (stockSnapshots == null || !stockSnapshots.isArray()) {
-                throw new CustomException(ErrorCode.BAD_GATEWAY, "네이버 주식 API 응답에 주식 데이터가 없습니다.");
+            if (stockSnapshots == null || !stockSnapshots.isArray()) { // 네이버 주식 API 응답에 주식 데이터가 없음
+                throw new CustomException(AnalysisErrorCode.STOCK_CURRENT_PRICE_RESPONSE_INVALID);
             }
 
-            if (stockSnapshots.isEmpty()) {
-                throw new CustomException(ErrorCode.NOT_FOUND, "존재하지 않는 종목 코드입니다.");
+            if (stockSnapshots.isEmpty()) { // 존재하지 않는 종목 코드에 대한 요청인 경우
+                throw new CustomException(AnalysisErrorCode.STOCK_CURRENT_PRICE_NOT_FOUND);
             }
 
             JsonNode stock = stockSnapshots.get(0);
             JsonNode closePriceRaw = stock.get("closePriceRaw");
 
-            if (closePriceRaw == null) {
-                throw new CustomException(ErrorCode.BAD_GATEWAY, "closePriceRaw 데이터가 없습니다.");
+            if (closePriceRaw == null) { // closePriceRaw 데이터가 없음
+                throw new CustomException(AnalysisErrorCode.STOCK_CURRENT_PRICE_RESPONSE_INVALID);
             }
 
             return closePriceRaw.asInt();
         } catch (CustomException e) {
             throw e;
         } catch (Exception e) {
-            throw new CustomException(ErrorCode.BAD_GATEWAY, "네이버 주식 API 처리 중 오류가 발생했습니다: " + e);
+            throw new CustomException(AnalysisErrorCode.STOCK_CURRENT_PRICE_API_FAILED);
         }
     }
 }

--- a/src/main/java/com/umc/finly/domain/analysis/infra/StockPriceProvider.java
+++ b/src/main/java/com/umc/finly/domain/analysis/infra/StockPriceProvider.java
@@ -1,0 +1,5 @@
+package com.umc.finly.domain.analysis.infra;
+
+public interface StockPriceProvider {
+    Integer getCurrentPrice(String stockCode);
+}

--- a/src/main/java/com/umc/finly/domain/analysis/infra/config/NaverStockRestClientConfig.java
+++ b/src/main/java/com/umc/finly/domain/analysis/infra/config/NaverStockRestClientConfig.java
@@ -20,8 +20,11 @@ public class NaverStockRestClientConfig {
                 .connectTimeout(Duration.ofSeconds(5)) // 연결 타임아웃
                 .build();
 
+        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(httpClient);
+        requestFactory.setReadTimeout(Duration.ofSeconds(5)); // 응답 타임아웃
+
         return RestClient.builder()
-                .requestFactory(new JdkClientHttpRequestFactory(httpClient))
+                .requestFactory(requestFactory)
                 .build();
     }
 }

--- a/src/main/java/com/umc/finly/domain/analysis/infra/config/NaverStockRestClientConfig.java
+++ b/src/main/java/com/umc/finly/domain/analysis/infra/config/NaverStockRestClientConfig.java
@@ -1,0 +1,27 @@
+package com.umc.finly.domain.analysis.infra.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+/**
+ * 네이버 주식 API 호출을 위한 RestClient 설정 클래스
+ * 외부 API 호출 시 타임아웃을 설정하여 무한 대기 상태로 인한 장애를 방지
+ */
+@Configuration
+public class NaverStockRestClientConfig {
+    @Bean
+    public RestClient naverStockRestClient() {
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5)) // 연결 타임아웃
+                .build();
+
+        return RestClient.builder()
+                .requestFactory(new JdkClientHttpRequestFactory(httpClient))
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/service/StockAnalysisService.java
+++ b/src/main/java/com/umc/finly/domain/analysis/service/StockAnalysisService.java
@@ -1,0 +1,7 @@
+package com.umc.finly.domain.analysis.service;
+
+import com.umc.finly.domain.analysis.dto.response.StockSummaryRes;
+
+public interface StockAnalysisService {
+    StockSummaryRes getStockSummary(String stockId);
+}

--- a/src/main/java/com/umc/finly/domain/analysis/service/StockAnalysisServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/service/StockAnalysisServiceImpl.java
@@ -1,0 +1,19 @@
+package com.umc.finly.domain.analysis.service;
+
+import com.umc.finly.domain.analysis.dto.response.StockSummaryRes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StockAnalysisServiceImpl implements StockAnalysisService {
+    private final StockPriceService stockPriceService;
+
+    @Override
+    public StockSummaryRes getStockSummary(String stockId) {
+        // TODO: 평균 매수 가액, 누적 매수 횟수, 최대 보유 기간 반환
+        Integer currentPrice = stockPriceService.getCurrentPrice(stockId);
+
+        return StockSummaryRes.currentPriceSummary(currentPrice);
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/service/StockPriceService.java
+++ b/src/main/java/com/umc/finly/domain/analysis/service/StockPriceService.java
@@ -1,0 +1,29 @@
+package com.umc.finly.domain.analysis.service;
+
+import com.umc.finly.domain.analysis.infra.StockPriceProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+/**
+ * 주식 종목의 현재가를 조회하는 서비스
+ * Spring Cache를 이용해 일정 시간 동안 캐싱하여 외부 API 호출 비용과 응답 지연을 줄이는 것을 목표로 함
+ */
+@Service
+@RequiredArgsConstructor
+public class StockPriceService {
+    private final StockPriceProvider stockPriceProvider;
+
+    /**
+     * 메서드 호출 결과를 캐시에 저장해두고, 같은 조건의 호출이 들어오면
+     * 메서드를 실행하지 않고 캐시 값을 바로 반환하는 어노테이션
+     */
+    @Cacheable(
+            value = "stockCurrentPrice", // 현재가 캐시 이름
+            key = "#stockCode",          // 종목 코드 기준으로 캐시
+            unless = "#result == null"   // 조회 실패(null)는 캐시하지 않음
+    )
+    public Integer getCurrentPrice(String stockCode) {
+        return stockPriceProvider.getCurrentPrice(stockCode);
+    }
+}

--- a/src/main/java/com/umc/finly/global/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/umc/finly/global/apiPayload/exception/ExceptionAdvice.java
@@ -76,6 +76,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     // 도메인 CustomException
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<Object> handleCustomException(CustomException e, HttpServletRequest request) {
+        log.error("CustomException 발생", e);
         ApiResponse<Object> body = ApiResponse.onFailure(e.getErrorCode(), null);
         WebRequest webRequest = new ServletWebRequest(request);
         return handleExceptionInternal(e, body, new HttpHeaders(), e.getErrorCode().getHttpStatus(), webRequest);

--- a/src/main/java/com/umc/finly/global/config/CacheConfig.java
+++ b/src/main/java/com/umc/finly/global/config/CacheConfig.java
@@ -1,0 +1,32 @@
+package com.umc.finly.global.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+    @Bean
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("stockCurrentPrice");
+        /**
+         * 요청 1 -> 네이버 API 호출 -> 캐시 저장
+         * 요청 2 (5초 이내) -> 캐시 반환
+         * 요청 3 (5초 후) -> 다시 네이버 API 호출
+         * 실시간 현재가는 아님 -> 네이버 API 과도 호출 방지 목적, 실시간 비슷하게 유지
+         */
+        cacheManager.setCaffeine(
+                Caffeine.newBuilder()
+                        .expireAfterWrite(5, TimeUnit.SECONDS)
+                        .maximumSize(1000) // 최대 1000개 종목까지만 캐시, 메모리 사용량 통제
+        );
+
+        return cacheManager;
+    }
+}

--- a/src/main/java/com/umc/finly/global/config/JacksonConfig.java
+++ b/src/main/java/com/umc/finly/global/config/JacksonConfig.java
@@ -1,0 +1,18 @@
+package com.umc.finly.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class JacksonConfig {
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        return JsonMapper.builder()
+                .findAndAddModules()
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #14

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

주식 분석 도메인에서 종목 분석 조회 API 일부 구현

- 종목 코드 기반 현재가 조회 기능 추가
- 네이버 금융 API 연동 및 Provider 분리
- Caffeine Cache를 적용하여 현재가 조회 성능 개선(TTL, 캐시 저장 개수 제한)
- 존재하지 않는 종목 코드 요청 시 404 예외 처리


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="2282" height="1458" alt="#14-1" src="https://github.com/user-attachments/assets/ea769e34-7e9b-42b6-8a9d-c8c3eefccfb1" />

<img width="2296" height="1454" alt="image" src="https://github.com/user-attachments/assets/ea3926ec-c703-4721-a417-35c9d865d2fc" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

- 현재는 엔티티 부재로 인해 종목 분석 정보 중 현재가만 우선 구현된 상태이며, 매수 기록 도메인 추가 시 확장할 예정입니다.
- 현재가 조회 시 사용하는 캐시는 Spring Cache(@Cacheable) 기반으로 구현되어 있어, 추후 Redis CacheManager로 교체 시 Service 코드 수정 없이 설정(CacheConfig)만 변경하시면 됩니다. @wonee1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 주식 분석 API 엔드포인트 추가 — 특정 종목 요약 정보 조회 가능
  * 실시간 주가 조회 연동 및 공급자 추가 — 외부 금융 API 호출로 현재가 조회
  * 종목 요약 응답 포맷 추가 — 요약값 반환 모델 제공

* **Chores**
  * 캐싱 도입 — Caffeine 기반, 5초 TTL 및 최대 1,000개 제한으로 외부 호출 감소
  * JSON 매핑 기본 설정 및 외부 호출 타임아웃 설정 추가
  * 예외 로깅 강화 및 관련 오류 코드 정리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->