### PR TITLE
[Feat] 시장 지표 조회 API 코스피, 코스닥 지수 조회 구현

### DIFF
--- a/src/main/java/com/umc/finly/domain/market/controller/MarketController.java
+++ b/src/main/java/com/umc/finly/domain/market/controller/MarketController.java
@@ -1,20 +1,23 @@
 package com.umc.finly.domain.market.controller;
 
 import com.umc.finly.domain.market.dto.MarketIndexResponse;
-import com.umc.finly.domain.market.dto.MarketInsightResponse;
-
-import com.umc.finly.global.apiPayload.exception.CustomException;
+import com.umc.finly.domain.market.service.MarketIndexService;
 import com.umc.finly.global.apiPayload.response.ApiResponse;
-import com.umc.finly.global.apiPayload.response.ErrorCode;
 import com.umc.finly.global.apiPayload.response.SuccessCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/market")
 @RequiredArgsConstructor
 public class MarketController {
+    private final MarketIndexService marketIndexService;
 
-
+    @GetMapping("/index")
+    public ApiResponse<MarketIndexResponse> getMarketIndex() {
+        return ApiResponse.onSuccess(
+                marketIndexService.getMarketIndex(),
+                SuccessCode.OK
+        );
+    }
 }

--- a/src/main/java/com/umc/finly/domain/market/dto/MarketIndexResponse.java
+++ b/src/main/java/com/umc/finly/domain/market/dto/MarketIndexResponse.java
@@ -1,12 +1,16 @@
 package com.umc.finly.domain.market.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
+@JsonPropertyOrder({ "kospi", "kosdaq", "fearGreed", "fearGreedStatus", "updatedAt" })
 @Getter
 @Builder
 @AllArgsConstructor
@@ -17,5 +21,15 @@ public class MarketIndexResponse {
     private BigDecimal kosdaq;
     private Integer fearGreed;
     private String fearGreedStatus;
-    private String updatedAt;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime updatedAt;
+
+    public static MarketIndexResponse snapshot(BigDecimal kospi, BigDecimal kosdaq) {
+        return MarketIndexResponse.builder()
+                .kospi(kospi)
+                .kosdaq(kosdaq)
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/src/main/java/com/umc/finly/domain/market/dto/MarketIndices.java
+++ b/src/main/java/com/umc/finly/domain/market/dto/MarketIndices.java
@@ -1,0 +1,13 @@
+package com.umc.finly.domain.market.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class MarketIndices {
+    private final BigDecimal kospi;
+    private final BigDecimal kosdaq;
+}

--- a/src/main/java/com/umc/finly/domain/market/exception/code/MarketErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/market/exception/code/MarketErrorCode.java
@@ -16,6 +16,16 @@ public enum MarketErrorCode implements BaseCode {
             "MARKET404",
             "시장 지표 데이터가 존재하지 않습니다."
     ),
+    MARKET_INDEX_API_FAILED(
+            ErrorCode.BAD_GATEWAY,
+            "MARKET502",
+            "시장 지표 조회 API 호출에 실패했습니다."
+    ),
+    MARKET_INDEX_RESPONSE_INVALID(
+            ErrorCode.BAD_GATEWAY,
+            "MARKET503",
+            "시장 지표 응답 형식이 올바르지 않습니다."
+    ),
 
     // 인사이트
     MARKET_INSIGHT_NOT_FOUND(

--- a/src/main/java/com/umc/finly/domain/market/infra/MarketIndexProvider.java
+++ b/src/main/java/com/umc/finly/domain/market/infra/MarketIndexProvider.java
@@ -1,0 +1,8 @@
+package com.umc.finly.domain.market.infra;
+
+import java.math.BigDecimal;
+
+public interface MarketIndexProvider {
+    BigDecimal getKospi();
+    BigDecimal getKosdaq();
+}

--- a/src/main/java/com/umc/finly/domain/market/infra/MarketIndexProvider.java
+++ b/src/main/java/com/umc/finly/domain/market/infra/MarketIndexProvider.java
@@ -1,8 +1,7 @@
 package com.umc.finly.domain.market.infra;
 
-import java.math.BigDecimal;
+import com.umc.finly.domain.market.dto.MarketIndices;
 
 public interface MarketIndexProvider {
-    BigDecimal getKospi();
-    BigDecimal getKosdaq();
+    MarketIndices getMarketIndices();
 }

--- a/src/main/java/com/umc/finly/domain/market/infra/NaverMarketIndexProvider.java
+++ b/src/main/java/com/umc/finly/domain/market/infra/NaverMarketIndexProvider.java
@@ -2,6 +2,7 @@ package com.umc.finly.domain.market.infra;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.finly.domain.market.dto.MarketIndices;
 import com.umc.finly.domain.market.exception.code.MarketErrorCode;
 import com.umc.finly.global.apiPayload.exception.CustomException;
 import lombok.RequiredArgsConstructor;
@@ -18,16 +19,7 @@ public class NaverMarketIndexProvider implements MarketIndexProvider {
     private final RestClient restClient;
 
     @Override
-    public BigDecimal getKospi() {
-        return getIndexValue("KOSPI");
-    }
-
-    @Override
-    public BigDecimal getKosdaq() {
-        return getIndexValue("KOSDAQ");
-    }
-
-    private BigDecimal getIndexValue(String key) {
+    public MarketIndices getMarketIndices() {
         try {
             String response = restClient.post()
                     .uri(NAVER_API_URL)
@@ -52,17 +44,30 @@ public class NaverMarketIndexProvider implements MarketIndexProvider {
                 throw new CustomException(MarketErrorCode.MARKET_INDEX_RESPONSE_INVALID);
             }
 
-            JsonNode indexNode = marketSnapshots.get(key);
+            BigDecimal kospi = extractIndex(marketSnapshots, "KOSPI");
+            BigDecimal kosdaq = extractIndex(marketSnapshots, "KOSDAQ");
 
-            if (indexNode == null) {
-                throw new CustomException(MarketErrorCode.MARKET_INDEX_NOT_FOUND);
-            }
-
-            return new BigDecimal(indexNode.get("closePriceRaw").asText());
+            return new MarketIndices(kospi, kosdaq);
         } catch (CustomException e) {
             throw e;
         } catch (Exception e) {
             throw new CustomException(MarketErrorCode.MARKET_INDEX_API_FAILED);
         }
+    }
+
+    private BigDecimal extractIndex(JsonNode marketSnapshots, String key) {
+        JsonNode indexNode = marketSnapshots.get(key);
+
+        if (indexNode == null) {
+            throw new CustomException(MarketErrorCode.MARKET_INDEX_NOT_FOUND);
+        }
+
+        JsonNode closePriceNode = indexNode.get("closePriceRaw");
+
+        if (closePriceNode == null || closePriceNode.isNull()) {
+            throw new CustomException(MarketErrorCode.MARKET_INDEX_RESPONSE_INVALID);
+        }
+
+        return new BigDecimal(closePriceNode.asText());
     }
 }

--- a/src/main/java/com/umc/finly/domain/market/infra/NaverMarketIndexProvider.java
+++ b/src/main/java/com/umc/finly/domain/market/infra/NaverMarketIndexProvider.java
@@ -1,0 +1,68 @@
+package com.umc.finly.domain.market.infra;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.finly.domain.market.exception.code.MarketErrorCode;
+import com.umc.finly.global.apiPayload.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.math.BigDecimal;
+
+@Component
+@RequiredArgsConstructor
+public class NaverMarketIndexProvider implements MarketIndexProvider {
+    private static final String NAVER_API_URL = "https://m.stock.naver.com/front-api/realTime/domestic/index";
+    private final ObjectMapper objectMapper;
+    private final RestClient restClient;
+
+    @Override
+    public BigDecimal getKospi() {
+        return getIndexValue("KOSPI");
+    }
+
+    @Override
+    public BigDecimal getKosdaq() {
+        return getIndexValue("KOSDAQ");
+    }
+
+    private BigDecimal getIndexValue(String key) {
+        try {
+            String response = restClient.post()
+                    .uri(NAVER_API_URL)
+                    .header("Content-Type", "application/json")
+                    .header("User-Agent",
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36")
+                    .header("Referer", "https://m.stock.naver.com/")
+                    .header("Origin", "https://m.stock.naver.com")
+                    .body("""
+                        {
+                          "itemCodes": ["KOSPI", "KOSDAQ"]
+                        }
+                    """)
+                    .retrieve()
+                    .body(String.class);
+
+            JsonNode root = objectMapper.readTree(response);
+
+            JsonNode marketSnapshots = root.at("/result/datas");
+
+            if (marketSnapshots.isMissingNode()) {
+                throw new CustomException(MarketErrorCode.MARKET_INDEX_RESPONSE_INVALID);
+            }
+
+            JsonNode indexNode = marketSnapshots.get(key);
+
+            if (indexNode == null) {
+                throw new CustomException(MarketErrorCode.MARKET_INDEX_NOT_FOUND);
+            }
+
+            return new BigDecimal(indexNode.get("closePriceRaw").asText());
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CustomException(MarketErrorCode.MARKET_INDEX_API_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/umc/finly/domain/market/service/MarketIndexService.java
+++ b/src/main/java/com/umc/finly/domain/market/service/MarketIndexService.java
@@ -1,6 +1,7 @@
 package com.umc.finly.domain.market.service;
 
 import com.umc.finly.domain.market.dto.MarketIndexResponse;
+import com.umc.finly.domain.market.dto.MarketIndices;
 import com.umc.finly.domain.market.infra.MarketIndexProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
@@ -16,9 +17,11 @@ public class MarketIndexService {
             unless = "#result == null"
     )
     public MarketIndexResponse getMarketIndex() {
+        MarketIndices indices = marketIndexProvider.getMarketIndices();
+
         return MarketIndexResponse.snapshot(
-                marketIndexProvider.getKospi(),
-                marketIndexProvider.getKosdaq()
+                indices.getKospi(),
+                indices.getKosdaq()
         );
     }
 }

--- a/src/main/java/com/umc/finly/domain/market/service/MarketIndexService.java
+++ b/src/main/java/com/umc/finly/domain/market/service/MarketIndexService.java
@@ -1,0 +1,24 @@
+package com.umc.finly.domain.market.service;
+
+import com.umc.finly.domain.market.dto.MarketIndexResponse;
+import com.umc.finly.domain.market.infra.MarketIndexProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MarketIndexService {
+    private final MarketIndexProvider marketIndexProvider;
+
+    @Cacheable(
+            value = "marketIndex",
+            unless = "#result == null"
+    )
+    public MarketIndexResponse getMarketIndex() {
+        return MarketIndexResponse.snapshot(
+                marketIndexProvider.getKospi(),
+                marketIndexProvider.getKosdaq()
+        );
+    }
+}

--- a/src/main/java/com/umc/finly/global/config/CacheConfig.java
+++ b/src/main/java/com/umc/finly/global/config/CacheConfig.java
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 public class CacheConfig {
     @Bean
     public CacheManager cacheManager() {
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager("stockCurrentPrice");
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("marketIndex", "stockCurrentPrice");
         /**
          * 요청 1 -> 네이버 API 호출 -> 캐시 저장
          * 요청 2 (5초 이내) -> 캐시 반환

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,9 +34,9 @@ spring:
       host: localhost
       port: 6379
 
-  jwt:
-    secret: ${JWT_SECRET}
-    access-token-expire-ms: ${JWT_ACCESS_TOKEN_EXPIRE_MS}
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expire-ms: ${JWT_ACCESS_TOKEN_EXPIRE_MS}
 
 logging:
   level:


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #22

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 네이버페이 증권 내부 API를 이용한 코스피·코스닥 지수 조회 로직 구현
- GET /api/market/index 엔드포인트 추가
- 코스피(KOSPI), 코스닥(KOSDAQ) 지수 조회 및 반환
- Spring Cache, Caffeine을 이용한 시장 지표 캐싱 적용
- MarketIndexProvider 인터페이스 도입으로 외부 API 교체 가능 구조 설계
- Market 도메인 전용 에러 코드 분리 및 적용


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="2880" height="1554" alt="#22-1" src="https://github.com/user-attachments/assets/4f96e041-775d-44ad-b24f-cf10c0db0a95" />

<img width="2288" height="1328" alt="#22-2" src="https://github.com/user-attachments/assets/ab4cc419-b1e0-4749-acfd-fcdd503f1db0" />

- 로컬 환경에서 API 정상 응답 확인

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

- application.yml에서 jwt: 블록을 spring: 블록 밖으로 꺼냈음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 시장 지표(KOSPI, KOSDAQ) 조회용 공개 엔드포인트 추가
  * 외부 제공자 연동으로 실시간 지표 수집 및 응답 제공
  * 시장 지표 캐시 도입으로 반복 조회 성능 향상

* **버그 수정**
  * 외부 응답 누락·형식 오류 및 조회 실패에 대한 처리 및 명확한 오류 응답 추가

* **개선사항**
  * 응답의 날짜-시간 직렬화 표준화 및 포맷 통일

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->