### PR TITLE
[Feat] 로그인 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/finly/domain/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.umc.finly.domain.auth.controller;
 
+import com.umc.finly.domain.auth.dto.req.AuthLoginReq;
 import com.umc.finly.domain.auth.dto.req.AuthSignUpReq;
+import com.umc.finly.domain.auth.dto.res.AuthLoginRes;
 import com.umc.finly.domain.auth.dto.res.AuthSignUpRes;
 import com.umc.finly.domain.auth.dto.res.CheckEmailRes;
 import com.umc.finly.domain.auth.exception.AuthErrorCode;
@@ -8,10 +10,13 @@ import com.umc.finly.domain.auth.service.AuthService;
 import com.umc.finly.global.apiPayload.exception.CustomException;
 import com.umc.finly.global.apiPayload.response.ApiResponse;
 import com.umc.finly.global.apiPayload.response.SuccessCode;
+import com.umc.finly.global.util.CookieUtil;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -23,6 +28,12 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+
+    private final CookieUtil cookieUtil;
+
+    // 로컬이라 false로 값 부여. 운영 단계에서 true로 키면 됨
+    @Value("${app.cookie.secure:false}")
+    private boolean cookieSecure;
 
     // 이메일 중복 확인
     @GetMapping("/check-email")
@@ -49,5 +60,23 @@ public class AuthController {
     public ApiResponse<AuthSignUpRes> signup(@RequestBody @Valid AuthSignUpReq request){
         AuthSignUpRes result = authService.signup(request);
         return ApiResponse.onSuccess(result, SuccessCode.CREATED);
+    }
+
+    // 로그인
+    @PostMapping("/login")
+    public ApiResponse<AuthLoginRes> login(
+            @RequestBody @Valid AuthLoginReq request,
+            HttpServletResponse response
+            ){
+        AuthService.LoginTokens tokens = authService.login(request);
+
+        cookieUtil.addRefreshTokenCookie(
+                response,
+                tokens.refreshToken(),
+                tokens.refreshMaxAgeSeconds(),
+                cookieSecure
+        );
+
+        return ApiResponse.onSuccess(tokens.body(), SuccessCode.OK);
     }
 }

--- a/src/main/java/com/umc/finly/domain/auth/dto/req/AuthLoginReq.java
+++ b/src/main/java/com/umc/finly/domain/auth/dto/req/AuthLoginReq.java
@@ -1,0 +1,17 @@
+package com.umc.finly.domain.auth.dto.req;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class AuthLoginReq {
+    // 로그인 DTO
+
+    @Email(message = "유효한 이메일이어야 합니다.")
+    @NotBlank(message = "이메일을 입력하세요.")
+    private String email;
+
+    @NotBlank(message = "비밀번호를 입력하세요.")
+    private String password;
+}

--- a/src/main/java/com/umc/finly/domain/auth/dto/res/AuthLoginRes.java
+++ b/src/main/java/com/umc/finly/domain/auth/dto/res/AuthLoginRes.java
@@ -1,6 +1,5 @@
 package com.umc.finly.domain.auth.dto.res;
 
-import com.umc.finly.domain.member.entity.Member;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,11 +9,11 @@ public class AuthLoginRes {
     // 로그인 응답 DTO
 
     private String accessToken;
-    private Member member;
+    private MemberInfo member;
 
     @Getter
     @Builder
-    public static class Member {
+    public static class MemberInfo {
         private Long memberId;
         private String email;
         private String nickname;

--- a/src/main/java/com/umc/finly/domain/auth/dto/res/AuthLoginRes.java
+++ b/src/main/java/com/umc/finly/domain/auth/dto/res/AuthLoginRes.java
@@ -1,0 +1,22 @@
+package com.umc.finly.domain.auth.dto.res;
+
+import com.umc.finly.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AuthLoginRes {
+    // 로그인 응답 DTO
+
+    private String accessToken;
+    private Member member;
+
+    @Getter
+    @Builder
+    public static class Member {
+        private Long memberId;
+        private String email;
+        private String nickname;
+    }
+}

--- a/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
@@ -17,7 +17,7 @@ public enum AuthErrorCode implements BaseCode {
     INVALID_PERSONA_ANSWERS(HttpStatus.BAD_REQUEST, "AUTH400_4", "페르소나 답변이 올바르지 않습니다."),
 
     // 401
-    INVALID_LOGIN_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH401", "비밀번호가 일치하지 않습니다."),
+    INVALID_LOGIN_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH401", "이메일 또는 비밀번호가 올바르지 않습니다."),
 
     // 422
     REQUIRED_TERM_NOT_AGREED(HttpStatus.UNPROCESSABLE_ENTITY, "AUTH422", "필수 약관에 동의해야 합니다.");

--- a/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
@@ -16,6 +16,9 @@ public enum AuthErrorCode implements BaseCode {
     INVALID_TERM_REQUEST(HttpStatus.BAD_REQUEST, "AUTH400_3", "약관 동의 요청이 올바르지 않습니다."),
     INVALID_PERSONA_ANSWERS(HttpStatus.BAD_REQUEST, "AUTH400_4", "페르소나 답변이 올바르지 않습니다."),
 
+    // 401
+    INVALID_LOGIN_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH401", "비밀번호가 일치하지 않습니다."),
+
     // 422
     REQUIRED_TERM_NOT_AGREED(HttpStatus.UNPROCESSABLE_ENTITY, "AUTH422", "필수 약관에 동의해야 합니다.");
 

--- a/src/main/java/com/umc/finly/domain/auth/service/AuthService.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/AuthService.java
@@ -1,10 +1,20 @@
 package com.umc.finly.domain.auth.service;
 
+import com.umc.finly.domain.auth.dto.req.AuthLoginReq;
 import com.umc.finly.domain.auth.dto.req.AuthSignUpReq;
+import com.umc.finly.domain.auth.dto.res.AuthLoginRes;
 import com.umc.finly.domain.auth.dto.res.AuthSignUpRes;
 
 public interface AuthService {
     boolean isEmailAvailable(String email);
 
     AuthSignUpRes signup(AuthSignUpReq request);
+
+    LoginTokens login(AuthLoginReq reqeust);
+
+    record LoginTokens(
+            AuthLoginRes body,
+            String refreshToken,
+            long refreshMaxAgeSeconds
+    ){}
 }

--- a/src/main/java/com/umc/finly/domain/auth/service/AuthService.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/AuthService.java
@@ -10,7 +10,7 @@ public interface AuthService {
 
     AuthSignUpRes signup(AuthSignUpReq request);
 
-    LoginTokens login(AuthLoginReq reqeust);
+    LoginTokens login(AuthLoginReq request);
 
     record LoginTokens(
             AuthLoginRes body,

--- a/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
@@ -117,10 +117,10 @@ public class AuthServiceImpl implements AuthService {
     public LoginTokens login(AuthLoginReq request){
         // 멤버 매칭
         Member member = memberRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new CustomException(AuthErrorCode.INVALID_LOGIN_PASSWORD));
+                .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         if(!passwordEncoder.matches(request.getPassword(), member.getPassword())){
-            throw new CustomException(MemberErrorCode.MEMBER_NOT_FOUND);
+            throw new CustomException(AuthErrorCode.INVALID_LOGIN_PASSWORD);
         }
 
         // 토큰 발급

--- a/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
@@ -137,7 +137,7 @@ public class AuthServiceImpl implements AuthService {
 
         AuthLoginRes result = AuthLoginRes.builder()
                 .accessToken("Bearer " + accessToken)
-                .member(AuthLoginRes.Member.builder()
+                .member(AuthLoginRes.MemberInfo.builder()
                         .memberId(member.getId())
                         .email(member.getEmail())
                         .nickname(member.getNickname())

--- a/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
@@ -117,7 +117,7 @@ public class AuthServiceImpl implements AuthService {
     public LoginTokens login(AuthLoginReq request){
         // 멤버 매칭
         Member member = memberRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(AuthErrorCode.INVALID_LOGIN_PASSWORD));
 
         if(!passwordEncoder.matches(request.getPassword(), member.getPassword())){
             throw new CustomException(AuthErrorCode.INVALID_LOGIN_PASSWORD);

--- a/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
@@ -1,6 +1,8 @@
 package com.umc.finly.domain.auth.service;
 
+import com.umc.finly.domain.auth.dto.req.AuthLoginReq;
 import com.umc.finly.domain.auth.dto.req.AuthSignUpReq;
+import com.umc.finly.domain.auth.dto.res.AuthLoginRes;
 import com.umc.finly.domain.auth.dto.res.AuthSignUpRes;
 import com.umc.finly.domain.auth.entity.Term;
 import com.umc.finly.domain.auth.entity.mapping.MemberTerm;
@@ -8,20 +10,23 @@ import com.umc.finly.domain.auth.enums.TermType;
 import com.umc.finly.domain.auth.exception.AuthErrorCode;
 import com.umc.finly.domain.auth.repository.TermRepository;
 import com.umc.finly.domain.member.dto.request.PersonaAnswerReq;
-import com.umc.finly.domain.member.dto.request.PersonaTestSubmitReq;
 import com.umc.finly.domain.member.entity.Member;
 import com.umc.finly.domain.member.entity.Persona;
 import com.umc.finly.domain.member.entity.mapping.MembersPersonasResult;
+import com.umc.finly.domain.member.exception.MemberErrorCode;
 import com.umc.finly.domain.member.repository.MemberPersonaResultRepository;
 import com.umc.finly.domain.member.repository.MemberRepository;
 import com.umc.finly.domain.member.repository.MemberTermRepository;
 import com.umc.finly.domain.member.service.PersonaScoringService;
 import com.umc.finly.global.apiPayload.exception.CustomException;
+import com.umc.finly.global.infra.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -34,13 +39,13 @@ import java.util.stream.Collectors;
 @Transactional
 public class AuthServiceImpl implements AuthService {
     private final MemberRepository memberRepository;
-    private final PasswordEncoder passwordEncoder;
-
     private final TermRepository termRepository;
     private final MemberTermRepository memberTermRepository;
-
     private final PersonaScoringService personaScoringService;
     private final MemberPersonaResultRepository memberPersonaResultRepository;
+
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
 
     // 비밀번호 양식
     private static final String PASSWORD_REGEX = "^(?=.*[A-Za-z])(?=.*\\d).{6,}$";
@@ -51,13 +56,13 @@ public class AuthServiceImpl implements AuthService {
     private static final EnumSet<TermType> REQUIRED_TERMS =
             EnumSet.of(TermType.TERMS_AGREED, TermType.PRIVACY_AGREED);
 
-    // 이메일 중복 확인
+    /** 이메일 중복 확인 **/
     @Override
     public boolean isEmailAvailable(String email) {
         return !memberRepository.existsByEmail(email);
     }
 
-    // 회원가입
+    /** 회원가입 **/
     @Override
     public AuthSignUpRes signup(AuthSignUpReq request){
         // 1. 이메일 중복 체크
@@ -107,6 +112,47 @@ public class AuthServiceImpl implements AuthService {
                 .build();
     }
 
+    /** 로그인 **/
+    @Override
+    public LoginTokens login(AuthLoginReq request){
+        // 멤버 매칭
+        Member member = memberRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new CustomException(AuthErrorCode.INVALID_LOGIN_PASSWORD));
+
+        if(!passwordEncoder.matches(request.getPassword(), member.getPassword())){
+            throw new CustomException(MemberErrorCode.MEMBER_NOT_FOUND);
+        }
+
+        // 토큰 발급
+        String accessToken = jwtProvider.createAccessToken(member.getId(), member.getEmail());
+        String refreshToken = jwtProvider.createRefreshToken(member.getId(), member.getEmail());
+
+        LocalDateTime refreshExpiredAt = LocalDateTime.ofInstant(
+                jwtProvider.getExpiration(refreshToken).toInstant(),
+                ZoneId.systemDefault()
+        );
+
+        member.updateRefreshToken(refreshToken, refreshExpiredAt);
+        memberRepository.save(member);
+
+        AuthLoginRes result = AuthLoginRes.builder()
+                .accessToken("Bearer " + accessToken)
+                .member(AuthLoginRes.Member.builder()
+                        .memberId(member.getId())
+                        .email(member.getEmail())
+                        .nickname(member.getNickname())
+                        .build())
+                .build();
+
+        long refreshMaxAgeSeconds = Math.max(
+                0,
+                (jwtProvider.getExpiration(refreshToken).getTime() - System.currentTimeMillis())/1000
+        );
+
+        return new LoginTokens(result, refreshToken, refreshMaxAgeSeconds);
+    }
+
+    // -----------------------------------------------------------
     private boolean isValidPassword(String raw) {
         return raw != null && raw.matches(PASSWORD_REGEX);
     }

--- a/src/main/java/com/umc/finly/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/member/exception/MemberErrorCode.java
@@ -9,12 +9,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberErrorCode implements BaseCode {
 
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "해당 이메일의 회원이 존재하지 않습니다."),
-
     PERSONA_ANSWERS_REQUIRED(HttpStatus.BAD_REQUEST, "MEMBER400", "Q1~Q3 답안은 모두 제출해야 합니다."),
     INVALID_PERSONA_ANSWER(HttpStatus.BAD_REQUEST, "MEMBER401", "질문/선택지 매핑이 올바르지 않습니다."),
     INVALID_PERSONA_MODE(HttpStatus.BAD_REQUEST, "MEMBER403", "persona mode 값이 올바르지 않습니다."),
-    PERSONA_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_2", "페르소나 결과를 찾을 수 없습니다.");
+    PERSONA_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "페르소나 결과를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/finly/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/member/exception/MemberErrorCode.java
@@ -9,12 +9,12 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberErrorCode implements BaseCode {
 
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "해당 이메일의 회원이 존재하지 않습니다."),
+
     PERSONA_ANSWERS_REQUIRED(HttpStatus.BAD_REQUEST, "MEMBER400", "Q1~Q3 답안은 모두 제출해야 합니다."),
     INVALID_PERSONA_ANSWER(HttpStatus.BAD_REQUEST, "MEMBER401", "질문/선택지 매핑이 올바르지 않습니다."),
     INVALID_PERSONA_MODE(HttpStatus.BAD_REQUEST, "MEMBER403", "persona mode 값이 올바르지 않습니다."),
-    PERSONA_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "페르소나 결과를 찾을 수 없습니다."),
-
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "해당 이메일의 회원이 존재하지 않습니다.");
+    PERSONA_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_2", "페르소나 결과를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/finly/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/member/exception/MemberErrorCode.java
@@ -12,7 +12,9 @@ public enum MemberErrorCode implements BaseCode {
     PERSONA_ANSWERS_REQUIRED(HttpStatus.BAD_REQUEST, "MEMBER400", "Q1~Q3 답안은 모두 제출해야 합니다."),
     INVALID_PERSONA_ANSWER(HttpStatus.BAD_REQUEST, "MEMBER401", "질문/선택지 매핑이 올바르지 않습니다."),
     INVALID_PERSONA_MODE(HttpStatus.BAD_REQUEST, "MEMBER403", "persona mode 값이 올바르지 않습니다."),
-    PERSONA_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "페르소나 결과를 찾을 수 없습니다.");
+    PERSONA_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "페르소나 결과를 찾을 수 없습니다."),
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "해당 이메일의 회원이 존재하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/finly/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/finly/domain/member/repository/MemberRepository.java
@@ -3,6 +3,9 @@ package com.umc.finly.domain.member.repository;
 import com.umc.finly.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/umc/finly/global/config/security/AuthPrincipal.java
+++ b/src/main/java/com/umc/finly/global/config/security/AuthPrincipal.java
@@ -1,0 +1,11 @@
+package com.umc.finly.global.config.security;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AuthPrincipal {
+    private final Long memberId;
+    private final String email;
+}

--- a/src/main/java/com/umc/finly/global/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/finly/global/config/security/JwtAuthenticationFilter.java
@@ -2,12 +2,16 @@ package com.umc.finly.global.config.security;
 
 import com.umc.finly.global.infra.jwt.JwtProvider;
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -20,7 +24,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             HttpServletRequest request,
             HttpServletResponse response,
             FilterChain filterChain
-    ) throws java.io.IOException, jakarta.servlet.ServletException{
+    ) throws IOException, ServletException {
 
         // 이미 인증이 세팅되어 있으면 스킵 (중복 세팅 방지)
         if (SecurityContextHolder.getContext().getAuthentication() != null) {
@@ -34,18 +38,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String token = authHeader.substring(7);
 
             if(jwtProvider.validateAccessToken(token)) {
-                try {
-                    Long memberId = jwtProvider.getMemberId(token);
 
-                    UsernamePasswordAuthenticationToken authentication =
-                            new UsernamePasswordAuthenticationToken(
-                                    memberId, null, null
-                            );
-                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                Long memberId = jwtProvider.getMemberId(token);
+                String email = jwtProvider.getEmail(token);
 
-                } catch (Exception ignored) {
-                    // 파싱/형변환 등 예외 나면 인증 세팅 없이 통과
-                }
+                AuthPrincipal principal = new AuthPrincipal(memberId, email);
+
+                UsernamePasswordAuthenticationToken authenticationToken =
+                        new UsernamePasswordAuthenticationToken(
+                                principal, null, Collections.emptyList()
+                        );
+                SecurityContextHolder.getContext().setAuthentication(authenticationToken);
             }
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/com/umc/finly/global/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/finly/global/config/security/JwtAuthenticationFilter.java
@@ -22,19 +22,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws java.io.IOException, jakarta.servlet.ServletException{
 
+        // 이미 인증이 세팅되어 있으면 스킵 (중복 세팅 방지)
+        if (SecurityContextHolder.getContext().getAuthentication() != null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String authHeader= request.getHeader("Authorization");
 
         if(authHeader != null && authHeader.startsWith("Bearer ")){
             String token = authHeader.substring(7);
 
-            if(jwtProvider.validate(token)){
-                Long memberId = jwtProvider.getMemberId(token);
+            if(jwtProvider.validateAccessToken(token)) {
+                try {
+                    Long memberId = jwtProvider.getMemberId(token);
 
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(
-                                memberId, null, null
-                        );
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(
+                                    memberId, null, null
+                            );
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                } catch (Exception ignored) {
+                    // 파싱/형변환 등 예외 나면 인증 세팅 없이 통과
+                }
             }
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/com/umc/finly/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/finly/global/config/security/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .httpBasic(basic -> basic.disable())
                 .authorizeHttpRequests(auth -> auth
                         // PUBLIC
-                        .requestMatchers("/api/persona-test/questions", "/api/auth/check-email","/api/auth/signup").permitAll()
+                        .requestMatchers("/api/persona-test/questions", "/api/auth/check-email","/api/auth/signup", "/api/auth/login").permitAll()
                         .requestMatchers(signupMatcher).permitAll()
 
                         // PROTECTED

--- a/src/main/java/com/umc/finly/global/infra/jwt/JwtProvider.java
+++ b/src/main/java/com/umc/finly/global/infra/jwt/JwtProvider.java
@@ -18,29 +18,39 @@ public class JwtProvider {
 
     private final SecretKey secretKey;
     private final long accessTokenExpireMs;
+    private final long refreshTokenExpireMs;
 
     public JwtProvider(
             @Value("${jwt.secret}") String secret,
-            @Value("${jwt.access-token-expire-ms}") long accessTokenExpireMs
+            @Value("${jwt.access-token-expire-ms}") long accessTokenExpireMs,
+            @Value("${jwt.refresh-token-expire-ms}") long refreshTokenExpireMs
     ) {
         this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
         this.accessTokenExpireMs = accessTokenExpireMs;
+        this.refreshTokenExpireMs = refreshTokenExpireMs;
     }
 
+    // token 생성
     public String createAccessToken(Long memberId, String email) {
-        return Jwts.builder()
-                .claim("memberId", memberId)
-                .claim("email", email)
-                .issuedAt(new Date())
-                .expiration(new Date(System.currentTimeMillis() + accessTokenExpireMs))
-                .signWith(secretKey, SignatureAlgorithm.HS256)
-                .compact();
+        return buildToken(memberId, email, "access", accessTokenExpireMs);
     }
 
+    public String createRefreshToken(Long memberId, String email){
+        return buildToken(memberId, email, "refresh", refreshTokenExpireMs);
+    }
+
+    // 토큰에서 추출
     public Long getMemberId(String token) {
         return parseClaims(token).get("memberId", Long.class);
     }
+    public String getEmail(String token) {
+        return parseClaims(token).get("email", String.class);
+    }
+    public String getTokenType(String token) {
+        return parseClaims(token).get("type", String.class);
+    }
 
+    // 서명/만료 등 기본 검증
     public boolean validate(String token) {
         try {
             parseClaims(token);
@@ -50,11 +60,56 @@ public class JwtProvider {
         }
     }
 
+    public boolean validateAccessToken(String token) {
+        try {
+            Claims claims = parseClaims(token);
+            return "access".equals(claims.get("type", String.class));
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public boolean validateRefreshToken(String token) {
+        try {
+            Claims claims = parseClaims(token);
+            return "refresh".equals(claims.get("type", String.class));
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    // 만료시간 변환 (디버깅/로직에 사용)
+    public Date getExpiration(String token) {
+        return parseClaims(token).getExpiration();
+    }
+
+    private String buildToken(Long memberId, String email, String type, long expireMs) {
+        long now = System.currentTimeMillis();
+        return Jwts.builder()
+                .claim("memberId", memberId)
+                .claim("email", email)
+                .claim("type", type)    // access | refresh
+                .setIssuedAt(new Date(now))
+                .setExpiration(new Date(now + expireMs))
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
     private Claims parseClaims(String token) {
+        String raw = resolveToken(token);
+
         return Jwts.parser()
                 .verifyWith(secretKey)
                 .build()
-                .parseSignedClaims(token)
+                .parseSignedClaims(raw)
                 .getPayload();
+    }
+
+    private String resolveToken(String token) {
+        if (token == null) return null;
+        if (token.startsWith("Bearer ")) {
+            return token.substring(7);
+        }
+        return token;
     }
 }

--- a/src/main/java/com/umc/finly/global/util/CookieUtil.java
+++ b/src/main/java/com/umc/finly/global/util/CookieUtil.java
@@ -1,0 +1,25 @@
+package com.umc.finly.global.util;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+    // 운영 환경에서 Secure=true 권장 (HTTPS)
+    public void addRefreshTokenCookie(HttpServletResponse response,
+                                      String refreshToken,
+                                      long maxAgeSeconds,
+                                      boolean secure){
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(secure)
+                .path("/api/auth")
+                .sameSite("Lax")
+                .maxAge(maxAgeSeconds)
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,7 @@ spring:
 jwt:
   secret: ${JWT_SECRET}
   access-token-expire-ms: ${JWT_ACCESS_TOKEN_EXPIRE_MS}
+  refresh-token-expire-ms: ${JWT_REFRESH_TOKEN_EXPIRE_MS}
 
 logging:
   level:


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #29 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- Login DTO 생성
- Login 서비스 구현
- JwtProvider에 refreshToken 관련 내용 추가
- refreshToken은 HttpOnly 쿠키(Set-Cookie)로 내림.

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
[로그인 실패 응답 확인하기](https://www.notion.so/2f6b7acc900f80618ae5d74c09c58abf?source=copy_link)


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.
<img width="1326" height="644" alt="image" src="https://github.com/user-attachments/assets/e05b4233-f594-4ec1-b846-a69eab3fe58d" />
<img width="706" height="304" alt="image" src="https://github.com/user-attachments/assets/61b36bd0-58b4-4b88-a043-702679b15022" />
<img width="758" height="178" alt="image" src="https://github.com/user-attachments/assets/9b0ded60-0945-4edf-b75b-8dd078240c37" />


## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.
- refreshToken 재발급 API 명세서를 노션에 추가했습니다.
현재는 accessToken 만료 시간을 길게 설정해 두어, 다른 기능 개발을 우선 진행한 뒤 reissue API를 구현해도 될 것 같습니다.
명세서 한 번 확인 부탁드립니다.

[토큰 재발급 API 명세서 확인하기](https://www.notion.so/API-2f6b7acc900f8096a38dcf1bdf539be9?source=copy_link)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이메일/비밀번호로 로그인 가능해졌습니다.
  * 로그인 시 액세스 토큰과 사용자 정보를 반환하고, 리프레시 토큰을 HTTP-only 쿠키로 안전하게 저장합니다.

* **버그 수정**
  * 잘못된 이메일·비밀번호 입력에 대한 명확한 인증 오류 메시지 추가.
  * 이미 인증된 요청에 대해 중복 인증 적용을 방지해 안정성 향상.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->