### PR TITLE
[Feat] 시장 지표 조회 API 공포·탐욕지수 조회 구현

### DIFF
--- a/src/main/java/com/umc/finly/domain/market/dto/FearGreedResult.java
+++ b/src/main/java/com/umc/finly/domain/market/dto/FearGreedResult.java
@@ -1,0 +1,12 @@
+package com.umc.finly.domain.market.dto;
+
+import com.umc.finly.domain.market.enums.FearGreedStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FearGreedResult {
+    private final Integer score;
+    private final FearGreedStatus status;
+}

--- a/src/main/java/com/umc/finly/domain/market/dto/MarketIndexResponse.java
+++ b/src/main/java/com/umc/finly/domain/market/dto/MarketIndexResponse.java
@@ -25,11 +25,18 @@ public class MarketIndexResponse {
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime updatedAt;
 
-    public static MarketIndexResponse snapshot(BigDecimal kospi, BigDecimal kosdaq) {
+    public static MarketIndexResponse snapshot(
+            BigDecimal kospi,
+            BigDecimal kosdaq,
+            Integer fearGreed,
+            String fearGreedStatus,
+            LocalDateTime updatedAt) {
         return MarketIndexResponse.builder()
                 .kospi(kospi)
                 .kosdaq(kosdaq)
-                .updatedAt(LocalDateTime.now())
+                .fearGreed(fearGreed)
+                .fearGreedStatus(fearGreedStatus)
+                .updatedAt(updatedAt)
                 .build();
     }
 }

--- a/src/main/java/com/umc/finly/domain/market/enums/FearGreedStatus.java
+++ b/src/main/java/com/umc/finly/domain/market/enums/FearGreedStatus.java
@@ -8,8 +8,18 @@ public enum FearGreedStatus {
     EXTREME_GREED;
 
     public static FearGreedStatus getFearGreedStatus(String rating) {
-        return FearGreedStatus.valueOf(
-                rating.toUpperCase().replace(" ", "_")
-        );
+        if (rating == null || rating.trim().isEmpty()) {
+            throw new IllegalArgumentException("rating can't be null or empty");
+        }
+
+        String normalizedRating = rating.toUpperCase().replace(" ", "_");
+
+        for (FearGreedStatus status : FearGreedStatus.values()) {
+            if (status.name().equals(normalizedRating)) {
+                return status;
+            }
+        }
+
+        throw new IllegalArgumentException("Unexpected fear/greed rating: " + rating);
     }
 }

--- a/src/main/java/com/umc/finly/domain/market/enums/FearGreedStatus.java
+++ b/src/main/java/com/umc/finly/domain/market/enums/FearGreedStatus.java
@@ -1,0 +1,15 @@
+package com.umc.finly.domain.market.enums;
+
+public enum FearGreedStatus {
+    EXTREME_FEAR,
+    FEAR,
+    NEUTRAL,
+    GREED,
+    EXTREME_GREED;
+
+    public static FearGreedStatus getFearGreedStatus(String rating) {
+        return FearGreedStatus.valueOf(
+                rating.toUpperCase().replace(" ", "_")
+        );
+    }
+}

--- a/src/main/java/com/umc/finly/domain/market/infra/CnnFearGreedIndexProvider.java
+++ b/src/main/java/com/umc/finly/domain/market/infra/CnnFearGreedIndexProvider.java
@@ -46,11 +46,23 @@ public class CnnFearGreedIndexProvider implements FearGreedIndexProvider {
                 throw new CustomException(MarketErrorCode.MARKET_INDEX_RESPONSE_INVALID);
             }
 
+            JsonNode scoreNode = data.get("score");
+
+            if (scoreNode == null || scoreNode.isNull()) {
+                throw new CustomException(MarketErrorCode.MARKET_INDEX_RESPONSE_INVALID);
+            }
+
             // 반올림
-            double rawScore = data.get("score").asDouble();
+            double rawScore = scoreNode.asDouble();
             int score = (int) Math.round(rawScore);
 
-            FearGreedStatus status = FearGreedStatus.getFearGreedStatus(data.get("rating").asText());
+            JsonNode ratingNode = data.get("rating");
+
+            if (ratingNode == null || ratingNode.isNull()) {
+                throw new CustomException(MarketErrorCode.MARKET_INDEX_RESPONSE_INVALID);
+            }
+
+            FearGreedStatus status = FearGreedStatus.getFearGreedStatus(ratingNode.asText());
 
             return new FearGreedResult(score, status);
         } catch (CustomException e) {

--- a/src/main/java/com/umc/finly/domain/market/infra/CnnFearGreedIndexProvider.java
+++ b/src/main/java/com/umc/finly/domain/market/infra/CnnFearGreedIndexProvider.java
@@ -1,0 +1,62 @@
+package com.umc.finly.domain.market.infra;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.finly.domain.market.dto.FearGreedResult;
+import com.umc.finly.domain.market.enums.FearGreedStatus;
+import com.umc.finly.domain.market.exception.code.MarketErrorCode;
+import com.umc.finly.global.apiPayload.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Locale;
+
+@Component
+@RequiredArgsConstructor
+public class CnnFearGreedIndexProvider implements FearGreedIndexProvider {
+    private static final String CNN_API_URL = "https://production.dataviz.cnn.io/index/fearandgreed/graphdata/%s";
+    private final ObjectMapper objectMapper;
+    private final RestClient restClient;
+
+    @Override
+    public FearGreedResult getFearGreedIndex() {
+        try {
+            // CNN은 미국 기준 날짜 사용
+            String date = LocalDate.now(ZoneId.of("America/New_York"))
+                    .format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.US));
+
+            String response = restClient.get()
+                    .uri(String.format(CNN_API_URL, date))
+                    .header("Content-Type", "application/json")
+                    .header("User-Agent",
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36")
+                    .header("Referer", "https://edition.cnn.com/")
+                    .header("Origin", "https://edition.cnn.com")
+                    .retrieve()
+                    .body(String.class);
+
+            JsonNode root = objectMapper.readTree(response);
+
+            JsonNode data = root.get("fear_and_greed");
+
+            if (data == null || data.isNull()) {
+                throw new CustomException(MarketErrorCode.MARKET_INDEX_RESPONSE_INVALID);
+            }
+
+            // 반올림
+            double rawScore = data.get("score").asDouble();
+            int score = (int) Math.round(rawScore);
+
+            FearGreedStatus status = FearGreedStatus.getFearGreedStatus(data.get("rating").asText());
+
+            return new FearGreedResult(score, status);
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CustomException(MarketErrorCode.MARKET_INDEX_API_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/umc/finly/domain/market/infra/FearGreedIndexProvider.java
+++ b/src/main/java/com/umc/finly/domain/market/infra/FearGreedIndexProvider.java
@@ -1,0 +1,7 @@
+package com.umc.finly.domain.market.infra;
+
+import com.umc.finly.domain.market.dto.FearGreedResult;
+
+public interface FearGreedIndexProvider {
+    FearGreedResult getFearGreedIndex();
+}

--- a/src/main/java/com/umc/finly/domain/market/service/MarketIndexService.java
+++ b/src/main/java/com/umc/finly/domain/market/service/MarketIndexService.java
@@ -1,16 +1,22 @@
 package com.umc.finly.domain.market.service;
 
+import com.umc.finly.domain.market.dto.FearGreedResult;
 import com.umc.finly.domain.market.dto.MarketIndexResponse;
 import com.umc.finly.domain.market.dto.MarketIndices;
+import com.umc.finly.domain.market.infra.FearGreedIndexProvider;
 import com.umc.finly.domain.market.infra.MarketIndexProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
 @Service
 @RequiredArgsConstructor
 public class MarketIndexService {
     private final MarketIndexProvider marketIndexProvider;
+    private final FearGreedIndexProvider fearGreedIndexProvider;
 
     @Cacheable(
             value = "marketIndex",
@@ -18,10 +24,15 @@ public class MarketIndexService {
     )
     public MarketIndexResponse getMarketIndex() {
         MarketIndices indices = marketIndexProvider.getMarketIndices();
+        FearGreedResult fearGreed = fearGreedIndexProvider.getFearGreedIndex();
+        LocalDateTime snapshotAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
 
         return MarketIndexResponse.snapshot(
                 indices.getKospi(),
-                indices.getKosdaq()
+                indices.getKosdaq(),
+                fearGreed.getScore(),
+                fearGreed.getStatus().name(),
+                snapshotAt
         );
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #40

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- FearGreedStatus enum 정의
- 공포·탐욕 지수(score) 및 상태(rating) 파싱/조회
- 소수점 점수 반올림 처리
- MarketIndexResponse에 fearGreed, fearGreedStatus 필드 추가


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="2880" height="1456" alt="#40-1" src="https://github.com/user-attachments/assets/6baea336-6f67-44c7-94fa-326b5080a604" />

<img width="2574" height="1464" alt="#40-2" src="https://github.com/user-attachments/assets/1df5aee4-0122-4a9c-bae4-aac8576bdb21" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Fear & Greed 지수가 시장 정보에 통합되어 응답에 점수와 상태가 포함됩니다.
  * CNN 기반 제공자를 통해 외부 Fear & Greed 데이터를 조회하여 반영합니다.
  * 시장 인덱스 조회 시 해당 지수의 조회 시각이 응답에 함께 제공됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->