### PR TITLE
[Deploy] 도커 기반 운영 환경 구성 및 Spring 설정 분리

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM eclipse-temurin:21-jdk
+
+WORKDIR /app
+
+COPY build/libs/finly-0.0.1-SNAPSHOT.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3.9"
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: finly-mysql
+    restart: always
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --default-time-zone=Asia/Seoul
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      retries: 10
+
+  backend:
+    build: .
+    image: finly-backend
+    container_name: finly-backend
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/${MYSQL_DATABASE}?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+      SPRING_DATASOURCE_USERNAME: ${MYSQL_USER}
+      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
+      JWT_SECRET: ${JWT_SECRET}
+      JWT_ACCESS_TOKEN_EXPIRE_MS: ${JWT_ACCESS_TOKEN_EXPIRE_MS}
+      JWT_REFRESH_TOKEN_EXPIRE_MS: ${JWT_REFRESH_TOKEN_EXPIRE_MS}
+    ports:
+      - "8080:8080"
+    restart: always
+
+volumes:
+  mysql-data:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,53 @@
+spring:
+  application:
+    name: finly
+
+  config:
+    import: optional:file:./.env[.properties]
+
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    show_sql: true
+    defer-datasource-initialization: true
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        format_sql: true
+        use_sql_comments: true
+        default_batch_fetch_size: 1000
+
+  sql:
+    init:
+      mode: never
+      continue-on-error: true
+      encoding: UTF-8
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expire-ms: ${JWT_ACCESS_TOKEN_EXPIRE_MS}
+  refresh-token-expire-ms: ${JWT_REFRESH_TOKEN_EXPIRE_MS}
+
+logging:
+  level:
+    root: INFO
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics
+  endpoint:
+    health:
+      show-details: always

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,7 +1,4 @@
 spring:
-  application:
-    name: finly
-
   config:
     import: optional:file:./.env[.properties]
 
@@ -33,21 +30,3 @@ spring:
     redis:
       host: localhost
       port: 6379
-
-jwt:
-  secret: ${JWT_SECRET}
-  access-token-expire-ms: ${JWT_ACCESS_TOKEN_EXPIRE_MS}
-  refresh-token-expire-ms: ${JWT_REFRESH_TOKEN_EXPIRE_MS}
-
-logging:
-  level:
-    root: INFO
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health, info, metrics
-  endpoint:
-    health:
-      show-details: always

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    url: ${SPRING_DATASOURCE_URL}
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    show_sql: false
+    hibernate:
+      ddl-auto: update
+
+  data:
+    redis:
+      host: redis
+      port: 6379

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -12,5 +12,5 @@ spring:
 
   data:
     redis:
-      host: redis
+      host: localhost
       port: 6379

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,52 +2,7 @@ spring:
   application:
     name: finly
 
-  config:
-    import: optional:file:./.env[.properties]
-
-  datasource:
-    url: ${DB_URL}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
-
-  jpa:
-    show_sql: true
-    defer-datasource-initialization: true
-    hibernate:
-      ddl-auto: update
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
-        format_sql: true
-        use_sql_comments: true
-        default_batch_fetch_size: 1000
-
-  sql:
-    init:
-      mode: never
-      continue-on-error: true
-      encoding: UTF-8
-
-  data:
-    redis:
-      host: localhost
-      port: 6379
-
 jwt:
   secret: ${JWT_SECRET}
   access-token-expire-ms: ${JWT_ACCESS_TOKEN_EXPIRE_MS}
   refresh-token-expire-ms: ${JWT_REFRESH_TOKEN_EXPIRE_MS}
-
-logging:
-  level:
-    root: INFO
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: health, info, metrics
-  endpoint:
-    health:
-      show-details: always

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,16 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expire-ms: ${JWT_ACCESS_TOKEN_EXPIRE_MS}
   refresh-token-expire-ms: ${JWT_REFRESH_TOKEN_EXPIRE_MS}
+
+logging:
+  level:
+    root: INFO
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics
+  endpoint:
+    health:
+      show-details: always


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

http://13.124.250.33:8080/swagger-ui/index.html

EC2 환경에서 Spring Boot 애플리케이션을 Docker로 배포하기 위한 로컬/운영 환경 설정 분리
Docker Compose를 이용한 MySQL 연동 구조 구성

Spring profile 분리
- application.yml: 공통 설정(JWT 등)만 유지
- application-local.yml: 로컬 개발 환경 설정
- application-prod.yml: 운영 환경 설정

Docker 기반 배포 환경 구성
- Dockerfile 추가 (Spring Boot JAR 실행)
- docker-compose.yml 구성
  - Spring Boot backend 컨테이너
  - MySQL 8.0 컨테이너

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

[로컬]
- SPRING_PROFILES_ACTIVE=local 설정 후 IntelliJ 실행
- API 정상 응답 확인

[Docker]
- ./gradlew build -x test
- docker compose up -d --build
- API 정상 응답 확인

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.


## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

- 현재 운영 환경은 Redis를 사용하지 않으므로 추후 Redis 도입 시 data: redis: host: 부분을 localhost에서 (redis=docker-compose 서비스명)로 변경해야 합니다.

- 로컬 실행 시 주의 사항

PR merge 후 git pull

IntelliJ → Run → Edit Configurations

Modify options → Environment variables 활성화

SPRING_PROFILES_ACTIVE=local 추가 후 실행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  - Docker 컨테이너화 지원으로 간편한 배포 가능

* **구성**
  - 로컬/프로덕션 환경별 설정 파일 분리
  - Docker Compose를 통한 MySQL, Redis 통합 관리
  - 환경 변수 기반 다중 환경 구성

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->