### PR TITLE
[Feat] 내 페르소나 결과 조회 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
@@ -19,6 +19,10 @@ public enum AuthErrorCode implements BaseCode {
     // 401
     INVALID_LOGIN_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH401", "이메일 또는 비밀번호가 올바르지 않습니다."),
 
+    UNATHORIZED(HttpStatus.UNAUTHORIZED, "AUTH401_1", "인증이 필요합니다. "),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_2", "토큰이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_3", "유효하지 않은 토큰입니다."),
+
     // 422
     REQUIRED_TERM_NOT_AGREED(HttpStatus.UNPROCESSABLE_ENTITY, "AUTH422", "필수 약관에 동의해야 합니다.");
 

--- a/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
@@ -23,6 +23,9 @@ public enum AuthErrorCode implements BaseCode {
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_2", "토큰이 만료되었습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_3", "유효하지 않은 토큰입니다."),
 
+    //403
+    FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH403", "접근 권한이 없습니다."),
+
     // 422
     REQUIRED_TERM_NOT_AGREED(HttpStatus.UNPROCESSABLE_ENTITY, "AUTH422", "필수 약관에 동의해야 합니다.");
 

--- a/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
@@ -1,0 +1,35 @@
+package com.umc.finly.domain.member.controller;
+
+import com.umc.finly.domain.auth.exception.AuthErrorCode;
+import com.umc.finly.domain.member.dto.response.MyPagePersonaRes;
+import com.umc.finly.domain.member.service.MyPageService;
+import com.umc.finly.global.apiPayload.exception.CustomException;
+import com.umc.finly.global.apiPayload.response.ApiResponse;
+import com.umc.finly.global.apiPayload.response.SuccessCode;
+import com.umc.finly.global.config.security.AuthPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/mypage")
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @GetMapping("/persona")
+    public ApiResponse<MyPagePersonaRes> getMyPersona(
+            @AuthenticationPrincipal AuthPrincipal principal
+    ){
+        if(principal == null){
+            throw new CustomException(AuthErrorCode.UNATHORIZED);
+        }
+        return ApiResponse.onSuccess(
+                myPageService.getMyPersona(principal.getMemberId()),
+                SuccessCode.OK
+        );
+    }
+}

--- a/src/main/java/com/umc/finly/domain/member/dto/response/MyPagePersonaRes.java
+++ b/src/main/java/com/umc/finly/domain/member/dto/response/MyPagePersonaRes.java
@@ -1,0 +1,26 @@
+package com.umc.finly.domain.member.dto.response;
+
+import com.umc.finly.domain.member.entity.mapping.MembersPersonasResult;
+import com.umc.finly.domain.member.enums.PersonaType;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MyPagePersonaRes {
+
+    private PersonaType personaType;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static MyPagePersonaRes from(MembersPersonasResult result){
+        return MyPagePersonaRes.builder()
+                .personaType(result.getPersona().getPersonaType())
+                .createdAt(result.getCreatedAt())
+                .updatedAt(result.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/member/dto/response/MyPagePersonaRes.java
+++ b/src/main/java/com/umc/finly/domain/member/dto/response/MyPagePersonaRes.java
@@ -1,7 +1,7 @@
 package com.umc.finly.domain.member.dto.response;
 
 import com.umc.finly.domain.member.entity.mapping.MembersPersonasResult;
-import com.umc.finly.domain.member.enums.PersonaType;
+import com.umc.finly.domain.member.enums.PersonaUiType;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -12,13 +12,13 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MyPagePersonaRes {
 
-    private PersonaType personaType;
+    private PersonaUiType personaType;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
     public static MyPagePersonaRes from(MembersPersonasResult result){
         return MyPagePersonaRes.builder()
-                .personaType(result.getPersona().getPersonaType())
+                .personaType(result.getPersona().getPersonaType().toUiType())
                 .createdAt(result.getCreatedAt())
                 .updatedAt(result.getUpdatedAt())
                 .build();

--- a/src/main/java/com/umc/finly/domain/member/enums/PersonaType.java
+++ b/src/main/java/com/umc/finly/domain/member/enums/PersonaType.java
@@ -16,4 +16,14 @@ public enum PersonaType {
     public String getDisplayName() {
         return displayName;
     }
+
+    // 프론트 UI 용 타입 변환
+    public PersonaUiType toUiType(){
+        return switch (this){
+            case WORRIED_DEER -> PersonaUiType.DEER;
+            case CAUTIOUS_TURTLE -> PersonaUiType.TURTLE;
+            case SHARP_EAGLE -> PersonaUiType.EAGLE;
+            case FIERY_LION -> PersonaUiType.LION;
+        };
+    }
 }

--- a/src/main/java/com/umc/finly/domain/member/enums/PersonaUiType.java
+++ b/src/main/java/com/umc/finly/domain/member/enums/PersonaUiType.java
@@ -1,0 +1,9 @@
+package com.umc.finly.domain.member.enums;
+
+// UI 전용 enum
+public enum PersonaUiType {
+    DEER,
+    TURTLE,
+    EAGLE,
+    LION
+}

--- a/src/main/java/com/umc/finly/domain/member/repository/MemberPersonaResultRepository.java
+++ b/src/main/java/com/umc/finly/domain/member/repository/MemberPersonaResultRepository.java
@@ -1,9 +1,9 @@
 package com.umc.finly.domain.member.repository;
 
 import com.umc.finly.domain.member.entity.mapping.MembersPersonasResult;
-import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 

--- a/src/main/java/com/umc/finly/domain/member/repository/MemberPersonaResultRepository.java
+++ b/src/main/java/com/umc/finly/domain/member/repository/MemberPersonaResultRepository.java
@@ -1,7 +1,9 @@
 package com.umc.finly.domain.member.repository;
 
 import com.umc.finly.domain.member.entity.mapping.MembersPersonasResult;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -9,6 +11,14 @@ public interface MemberPersonaResultRepository extends JpaRepository<MembersPers
 
     // 회원의 페르소나 결과 1건 조회
     // retest 시 업데이트
-    // result 조회 API 에서도 사용할 예정
     Optional<MembersPersonasResult> findByMemberId(Long memId);
+
+    // 마이페이지 페르소나 조회 API
+    @Query("""
+        select mpr
+        from MembersPersonasResult mpr
+        join fetch mpr.persona p
+        where mpr.memberId = :memberId
+""")
+    Optional<MembersPersonasResult> findByMemberIdFetchPersona(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageService.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageService.java
@@ -1,0 +1,7 @@
+package com.umc.finly.domain.member.service;
+
+import com.umc.finly.domain.member.dto.response.MyPagePersonaRes;
+
+public interface MyPageService {
+    MyPagePersonaRes getMyPersona(Long memberId);
+}

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
@@ -1,0 +1,27 @@
+package com.umc.finly.domain.member.service;
+
+import com.umc.finly.domain.member.dto.response.MyPagePersonaRes;
+import com.umc.finly.domain.member.exception.MemberErrorCode;
+import com.umc.finly.domain.member.repository.MemberPersonaResultRepository;
+import com.umc.finly.global.apiPayload.exception.CustomException;
+import com.umc.finly.global.util.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPageServiceImpl implements MyPageService{
+    // MyPage 관련 서비스
+
+    private final MemberPersonaResultRepository memberPersonaResultRepository;
+
+    // 내 페르소나 조회
+    @Override
+    public MyPagePersonaRes getMyPersona(Long memberId){
+        return memberPersonaResultRepository.findByMemberIdFetchPersona(memberId)
+                .map(MyPagePersonaRes::from)
+                .orElseThrow(()-> new CustomException(MemberErrorCode.PERSONA_RESULT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/umc/finly/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/finly/global/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.umc.finly.global.config.security;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umc.finly.domain.auth.exception.AuthErrorCode;
 import com.umc.finly.global.apiPayload.response.ApiResponse;
 import com.umc.finly.global.infra.jwt.JwtProvider;
@@ -14,7 +15,6 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.RequestMatcher;
-import tools.jackson.databind.ObjectMapper;
 import org.springframework.http.MediaType;
 
 import java.awt.*;

--- a/src/main/java/com/umc/finly/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/finly/global/config/security/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.umc.finly.global.config.security;
 
+import com.umc.finly.domain.auth.exception.AuthErrorCode;
+import com.umc.finly.global.apiPayload.response.ApiResponse;
 import com.umc.finly.global.infra.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -7,9 +9,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import tools.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+
+import java.awt.*;
 
 @Configuration
 @RequiredArgsConstructor
@@ -20,6 +28,12 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
+        /*
+         * [동적 RequestMatcher]
+         * - 같은 URI라도 query parameter(mode)에 따라 접근 권한을 다르게 주기 위함
+         * - /api/persona-test/submit?mode=signup  → 인증 없이 허용
+         * - /api/persona-test/submit?mode=retest → 로그인(JWT) 필요
+         */
         RequestMatcher signupMatcher = request ->
                 "/api/persona-test/submit".equals(request.getServletPath()) &&
                         "signup".equals(request.getParameter("mode"));
@@ -28,10 +42,46 @@ public class SecurityConfig {
                 "/api/persona-test/submit".equals(request.getServletPath()) &&
                         "retest".equals(request.getParameter("mode"));
 
+        /*
+         * [인증/인가 실패 시 JSON 응답을 내려주기 위한 설정]
+         * - AuthenticationEntryPoint : 인증 자체가 안 된 경우 (401)
+         * - AccessDeniedHandler      : 인증은 됐지만 권한이 없는 경우 (403)
+         * - 기본 HTML 응답 대신 ApiResponse 형태의 JSON으로 통일
+         */
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        AuthenticationEntryPoint entryPoint = (request, response, authException) -> {
+            response.setStatus(AuthErrorCode.UNATHORIZED.getHttpStatus().value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+
+            ApiResponse<Object> body = ApiResponse.onFailure(
+                    AuthErrorCode.UNATHORIZED,
+                    AuthErrorCode.UNATHORIZED.getMessage()
+            );
+
+            objectMapper.writeValue(response.getWriter(), body);
+        };
+
+        AccessDeniedHandler deniedHandler = (request, response, accessDeniedHandler) -> {
+            response.setStatus(AuthErrorCode.FORBIDDEN.getHttpStatus().value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+            response.setCharacterEncoding("UTF-8");
+
+            ApiResponse<Object> body = ApiResponse.onFailure(
+                    AuthErrorCode.FORBIDDEN,
+                    AuthErrorCode.FORBIDDEN.getMessage()
+            );
+
+            objectMapper.writeValue(response.getWriter(), body);
+        };
+
         http
+                /** [기존 보안 기능 비활성화] **/
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
+                /** [URL 접근 권한 설정] **/
                 .authorizeHttpRequests(auth -> auth
                         // PUBLIC
                         .requestMatchers("/auth/**", "/api/persona-test/questions").permitAll()
@@ -44,6 +94,20 @@ public class SecurityConfig {
                         // 나머지
                         .anyRequest().permitAll()
                 )
+                /*
+                 * [인증/인가 실패 시 처리 로직 연결]
+                 * - 로그인 안 함 / 토큰 없음 / 만료 → 401 (AuthenticationEntryPoint)
+                 * - 로그인 했지만 접근 권한 없음 → 403 (AccessDeniedHandler)
+                 */
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(entryPoint)
+                        .accessDeniedHandler(deniedHandler))
+                /*
+                 * [JWT 인증 필터 등록]
+                 * - UsernamePasswordAuthenticationFilter 이전에 실행
+                 * - Authorization: Bearer {token} 헤더에서 JWT 추출
+                 * - 유효한 경우 SecurityContext에 AuthPrincipal 세팅
+                 */
                 .addFilterBefore(
                         new JwtAuthenticationFilter(jwtProvider),
                         UsernamePasswordAuthenticationFilter.class

--- a/src/main/java/com/umc/finly/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/finly/global/config/security/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
                         .requestMatchers(signupMatcher).permitAll()
 
                         // PROTECTED
+                        .requestMatchers("/api/mypage/**").authenticated()
                         .requestMatchers(retestMatcher).authenticated()
 
                         // 나머지


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #39 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 프론트용 PersonaUiType 이넘 클래스 추가, 기존 이넘 클래스와 연결 
- 마이페이지의 내 페르소나 조회 api 기능 구현
- JWT 관련 401 에러코드 AuthErrorCode 에 추가
- 로그인하지 않은 요청에 대해 401, 권한 부족 요청에 대해 403을 명확히 구분하도록 보안 예외 처리 추가
- SecurityConfig에 AuthenticationEntryPoint와 AccessDeniedHandler를 등록해 JSON 형태의 공통 에러 응답 반환

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="1368" height="688" alt="image" src="https://github.com/user-attachments/assets/929ab8e8-4557-47c5-a746-0da8cc34793f" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.
- 프론트 코드 참고해 api 명세서에 PersonaType 넘기는걸로 수정했습니다. 
[api 명세서](https://www.notion.so/2e9b7acc900f80b4ac5de4e6bbce7191?source=copy_link)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 마이페이지에서 사용자의 페르소나 조회 API 및 응답 포맷 추가
  * 페르소나 UI 유형(4종) 지원 및 응답 변환 기능 추가

* **Chores**
  * 인증 실패(미인증, 토큰 만료/유효성) 및 권한 거부에 대한 명확한 오류 코드·응답 추가
  * 보안 처리 강화 및 인증/권한 실패 시 JSON 오류 응답 제공하도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->