### PR TITLE
[Refactor] 페르소나 테스트 retest 인증 흐름 정리 

### DIFF
--- a/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
@@ -19,7 +19,7 @@ public enum AuthErrorCode implements BaseCode {
     // 401
     INVALID_LOGIN_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH401", "이메일 또는 비밀번호가 올바르지 않습니다."),
 
-    UNATHORIZED(HttpStatus.UNAUTHORIZED, "AUTH401_1", "인증이 필요합니다. "),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH401_1", "인증이 필요합니다. "),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_2", "토큰이 만료되었습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_3", "유효하지 않은 토큰입니다."),
 

--- a/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
@@ -25,7 +25,7 @@ public class MyPageController {
             @AuthenticationPrincipal AuthPrincipal principal
     ){
         if(principal == null){
-            throw new CustomException(AuthErrorCode.UNATHORIZED);
+            throw new CustomException(AuthErrorCode.UNAUTHORIZED);
         }
         return ApiResponse.onSuccess(
                 myPageService.getMyPersona(principal.getMemberId()),

--- a/src/main/java/com/umc/finly/domain/member/controller/PersonasTestController.java
+++ b/src/main/java/com/umc/finly/domain/member/controller/PersonasTestController.java
@@ -1,5 +1,6 @@
 package com.umc.finly.domain.member.controller;
 
+import com.umc.finly.domain.auth.exception.AuthErrorCode;
 import com.umc.finly.domain.member.dto.request.PersonaTestSubmitReq;
 import com.umc.finly.domain.member.dto.response.PersonaTestQuestionRes;
 import com.umc.finly.domain.member.dto.response.PersonaTestSubmitRes;
@@ -9,7 +10,9 @@ import com.umc.finly.domain.member.service.PersonaTestSubmitService;
 import com.umc.finly.global.apiPayload.exception.CustomException;
 import com.umc.finly.global.apiPayload.response.ApiResponse;
 import com.umc.finly.global.apiPayload.response.SuccessCode;
+import com.umc.finly.global.config.security.AuthPrincipal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -39,13 +42,23 @@ public class PersonasTestController {
     @PostMapping("/submit")
     public ApiResponse<PersonaTestSubmitRes> submit(
             @RequestParam("mode") String mode,
-            @RequestBody PersonaTestSubmitReq request
-    ){
+            @RequestBody PersonaTestSubmitReq request,
+            @AuthenticationPrincipal AuthPrincipal authPrincipal
+            ){
         if (!"signup".equals(mode) && !"retest".equals(mode)) {
             throw new CustomException(MemberErrorCode.INVALID_PERSONA_MODE);
         }
+
+        Long memberId = null;
+        if("retest".equals(mode)){
+            if (authPrincipal==null){
+                throw new CustomException(AuthErrorCode.UNATHORIZED);
+            }
+            memberId = authPrincipal.getMemberId();
+        }
+
         return ApiResponse.onSuccess(
-                submitService.submit(mode, request),
+                submitService.submit(mode, memberId, request),
                 SuccessCode.OK
         );
     }

--- a/src/main/java/com/umc/finly/domain/member/controller/PersonasTestController.java
+++ b/src/main/java/com/umc/finly/domain/member/controller/PersonasTestController.java
@@ -52,7 +52,7 @@ public class PersonasTestController {
         Long memberId = null;
         if("retest".equals(mode)){
             if (authPrincipal==null){
-                throw new CustomException(AuthErrorCode.UNATHORIZED);
+                throw new CustomException(AuthErrorCode.UNAUTHORIZED);
             }
             memberId = authPrincipal.getMemberId();
         }

--- a/src/main/java/com/umc/finly/domain/member/dto/response/PersonaTestSubmitRes.java
+++ b/src/main/java/com/umc/finly/domain/member/dto/response/PersonaTestSubmitRes.java
@@ -1,5 +1,6 @@
 package com.umc.finly.domain.member.dto.response;
 
+import com.umc.finly.domain.member.enums.PersonaUiType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,21 +9,8 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 public class PersonaTestSubmitRes {
-    // 최종 계산된 페르소나 정보
-
-    private PersonaRes persona;
+    private PersonaUiType personaType;
     private boolean saved;
     private LocalDateTime createdAt;    // 최초 페르소나 결과 생성 시각
     private LocalDateTime updatedAt;    // 최근 페르소나 재테스트 결과 생성 시각
-
-    @Getter
-    @Builder
-    public static class PersonaRes {
-        // 페르소나 상세 정보 응답 DTO
-
-        private Long id;
-        private String title;
-        private String description;
-        private String iconUrl;
-    }
 }

--- a/src/main/java/com/umc/finly/domain/member/service/PersonaTestSubmitService.java
+++ b/src/main/java/com/umc/finly/domain/member/service/PersonaTestSubmitService.java
@@ -5,5 +5,5 @@ import com.umc.finly.domain.member.dto.response.PersonaTestSubmitRes;
 
 public interface PersonaTestSubmitService {
 
-    PersonaTestSubmitRes submit(String mode, PersonaTestSubmitReq request);
+    PersonaTestSubmitRes submit(String mode, Long memberId, PersonaTestSubmitReq request);
 }

--- a/src/main/java/com/umc/finly/domain/member/service/PersonaTestSubmitServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/member/service/PersonaTestSubmitServiceImpl.java
@@ -8,7 +8,6 @@ import com.umc.finly.domain.member.entity.mapping.MembersPersonasResult;
 import com.umc.finly.domain.member.exception.MemberErrorCode;
 import com.umc.finly.domain.member.repository.MemberPersonaResultRepository;
 import com.umc.finly.global.apiPayload.exception.CustomException;
-import com.umc.finly.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,13 +44,14 @@ public class PersonaTestSubmitServiceImpl implements PersonaTestSubmitService{
                             .map(existing -> existing.updatePersona(persona))
                             .orElseGet(() -> MembersPersonasResult.create(memberId, persona));
 
-            memberPersonaResultRepository.save(result);
+            MembersPersonasResult saved =
+                    memberPersonaResultRepository.saveAndFlush(result);
 
             return buildResponse(
                     persona,
                     true,
-                    result.getCreatedAt(),
-                    result.getUpdatedAt()
+                    saved.getCreatedAt(),
+                    saved.getUpdatedAt()
             );
         }
 
@@ -64,15 +64,9 @@ public class PersonaTestSubmitServiceImpl implements PersonaTestSubmitService{
             LocalDateTime createdAt,
             LocalDateTime updatedAt
     ) {
+
         return PersonaTestSubmitRes.builder()
-                .persona(
-                        PersonaTestSubmitRes.PersonaRes.builder()
-                                .id(persona.getId())
-                                .title(persona.getTitle())
-                                .description(persona.getDescription())
-                                .iconUrl(persona.getIconUrl())
-                                .build()
-                )
+                .personaType(persona.getPersonaType().toUiType())
                 .saved(saved)
                 .createdAt(createdAt)
                 .updatedAt(updatedAt)

--- a/src/main/java/com/umc/finly/domain/member/service/PersonaTestSubmitServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/member/service/PersonaTestSubmitServiceImpl.java
@@ -1,5 +1,6 @@
 package com.umc.finly.domain.member.service;
 
+import com.umc.finly.domain.auth.exception.AuthErrorCode;
 import com.umc.finly.domain.member.dto.request.PersonaTestSubmitReq;
 import com.umc.finly.domain.member.dto.response.PersonaTestSubmitRes;
 import com.umc.finly.domain.member.entity.Persona;
@@ -22,7 +23,7 @@ public class PersonaTestSubmitServiceImpl implements PersonaTestSubmitService{
     private final MemberPersonaResultRepository memberPersonaResultRepository;
 
     @Override
-    public PersonaTestSubmitRes submit(String mode, PersonaTestSubmitReq request){
+    public PersonaTestSubmitRes submit(String mode, Long memberId, PersonaTestSubmitReq request){
 
         // 공용 채점/검증 로직 재사용
         Persona persona = personaScoringService.resolvePersona(request.getAnswers());
@@ -34,8 +35,10 @@ public class PersonaTestSubmitServiceImpl implements PersonaTestSubmitService{
         }
 
         if ("retest".equals(mode)) {
-            // 로그인 후 재테스트: JWT필요
-            Long memberId = SecurityUtil.getCurrentMemberId();
+            // 로그인 후 재테스트
+            if (memberId == null){
+                throw new CustomException(AuthErrorCode.UNATHORIZED);
+            }
 
             MembersPersonasResult result =
                     memberPersonaResultRepository.findByMemberId(memberId)

--- a/src/main/java/com/umc/finly/domain/member/service/PersonaTestSubmitServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/member/service/PersonaTestSubmitServiceImpl.java
@@ -36,7 +36,7 @@ public class PersonaTestSubmitServiceImpl implements PersonaTestSubmitService{
         if ("retest".equals(mode)) {
             // 로그인 후 재테스트
             if (memberId == null){
-                throw new CustomException(AuthErrorCode.UNATHORIZED);
+                throw new CustomException(AuthErrorCode.UNAUTHORIZED);
             }
 
             MembersPersonasResult result =

--- a/src/main/java/com/umc/finly/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/finly/global/config/security/SecurityConfig.java
@@ -17,8 +17,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.http.MediaType;
 
-import java.awt.*;
-
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
@@ -51,13 +49,13 @@ public class SecurityConfig {
         ObjectMapper objectMapper = new ObjectMapper();
 
         AuthenticationEntryPoint entryPoint = (request, response, authException) -> {
-            response.setStatus(AuthErrorCode.UNATHORIZED.getHttpStatus().value());
+            response.setStatus(AuthErrorCode.UNAUTHORIZED.getHttpStatus().value());
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setCharacterEncoding("UTF-8");
 
             ApiResponse<Object> body = ApiResponse.onFailure(
-                    AuthErrorCode.UNATHORIZED,
-                    AuthErrorCode.UNATHORIZED.getMessage()
+                    AuthErrorCode.UNAUTHORIZED,
+                    AuthErrorCode.UNAUTHORIZED.getMessage()
             );
 
             objectMapper.writeValue(response.getWriter(), body);


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #52 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- PersonaTestSubmit mode=retest 시 JWT 토큰 인증으로 수정
- response DTO에서 페르소나 정보를 PersonaType만 반환하는 걸로 수정 
- 에러코드 오타 수정

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
### retest 전
<img width="1208" height="692" alt="image" src="https://github.com/user-attachments/assets/f8d8ed05-bf15-49f7-ac6f-114b6b2c47a2" />

### retest 실행
<img width="1074" height="732" alt="image" src="https://github.com/user-attachments/assets/0eb88a72-2e60-42fc-b3cc-d00f38c6a123" />

### retest 후 내 페르소나 조회
<img width="1114" height="692" alt="image" src="https://github.com/user-attachments/assets/8359c0b2-90f8-4246-9156-efc6ac61a281" />

### 로컬 DB로 수정사항 확인
<img width="1304" height="436" alt="image" src="https://github.com/user-attachments/assets/fd5ae271-94c8-474f-b93a-dd86ddbf4e04" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.
- createdAt : 회원가입 때 시점으로 고정, updatedAt : retest마다 갱신
- retest 시 페르소나 결과가 변하지 않으면 DB에 새로 업데이트 되지 않습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인증 에러 코드의 오타를 수정했습니다.
  
* **개선 사항**
  * 성격 테스트 제출 시 인증 검증을 강화했습니다.
  * 성격 테스트 응답 형식을 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->