### PR TITLE
[Feat] 내 프로필 조회 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
@@ -1,6 +1,7 @@
 package com.umc.finly.domain.member.controller;
 
 import com.umc.finly.domain.auth.exception.AuthErrorCode;
+import com.umc.finly.domain.member.dto.response.MyPageMeRes;
 import com.umc.finly.domain.member.dto.response.MyPagePersonaRes;
 import com.umc.finly.domain.member.service.MyPageService;
 import com.umc.finly.global.apiPayload.exception.CustomException;
@@ -20,6 +21,7 @@ public class MyPageController {
 
     private final MyPageService myPageService;
 
+    // 내 페르소나 조회
     @GetMapping("/persona")
     public ApiResponse<MyPagePersonaRes> getMyPersona(
             @AuthenticationPrincipal AuthPrincipal principal
@@ -29,6 +31,17 @@ public class MyPageController {
         }
         return ApiResponse.onSuccess(
                 myPageService.getMyPersona(principal.getMemberId()),
+                SuccessCode.OK
+        );
+    }
+
+    // 내 프로필 조회
+    @GetMapping("/me")
+    public ApiResponse<MyPageMeRes> getMyInfo(
+            @AuthenticationPrincipal AuthPrincipal principal
+    ){
+        return ApiResponse.onSuccess(
+                myPageService.getMyInfo(principal.getMemberId()),
                 SuccessCode.OK
         );
     }

--- a/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
@@ -40,6 +40,10 @@ public class MyPageController {
     public ApiResponse<MyPageMeRes> getMyInfo(
             @AuthenticationPrincipal AuthPrincipal principal
     ){
+        if (principal == null){
+            throw new CustomException(AuthErrorCode.UNAUTHORIZED);
+        }
+
         return ApiResponse.onSuccess(
                 myPageService.getMyInfo(principal.getMemberId()),
                 SuccessCode.OK

--- a/src/main/java/com/umc/finly/domain/member/dto/response/MyPageMeRes.java
+++ b/src/main/java/com/umc/finly/domain/member/dto/response/MyPageMeRes.java
@@ -1,0 +1,24 @@
+package com.umc.finly.domain.member.dto.response;
+
+import com.umc.finly.domain.member.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MyPageMeRes {
+
+    private Long memberId;
+    private String email;
+    private String nickname;
+
+    public static MyPageMeRes from(Member member){
+        return MyPageMeRes.builder()
+                .memberId(member.getId())
+                .email(member.getEmail())
+                .nickname(member.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/member/exception/MemberErrorCode.java
@@ -12,7 +12,8 @@ public enum MemberErrorCode implements BaseCode {
     PERSONA_ANSWERS_REQUIRED(HttpStatus.BAD_REQUEST, "MEMBER400", "Q1~Q3 답안은 모두 제출해야 합니다."),
     INVALID_PERSONA_ANSWER(HttpStatus.BAD_REQUEST, "MEMBER401", "질문/선택지 매핑이 올바르지 않습니다."),
     INVALID_PERSONA_MODE(HttpStatus.BAD_REQUEST, "MEMBER403", "persona mode 값이 올바르지 않습니다."),
-    PERSONA_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "페르소나 결과를 찾을 수 없습니다.");
+    PERSONA_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404", "페르소나 결과를 찾을 수 없습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "멤버를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageService.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageService.java
@@ -1,7 +1,10 @@
 package com.umc.finly.domain.member.service;
 
+import com.umc.finly.domain.member.dto.response.MyPageMeRes;
 import com.umc.finly.domain.member.dto.response.MyPagePersonaRes;
 
 public interface MyPageService {
     MyPagePersonaRes getMyPersona(Long memberId);
+
+    MyPageMeRes getMyInfo(Long memberId);
 }

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
@@ -1,10 +1,12 @@
 package com.umc.finly.domain.member.service;
 
+import com.umc.finly.domain.member.dto.response.MyPageMeRes;
 import com.umc.finly.domain.member.dto.response.MyPagePersonaRes;
+import com.umc.finly.domain.member.entity.Member;
 import com.umc.finly.domain.member.exception.MemberErrorCode;
 import com.umc.finly.domain.member.repository.MemberPersonaResultRepository;
+import com.umc.finly.domain.member.repository.MemberRepository;
 import com.umc.finly.global.apiPayload.exception.CustomException;
-import com.umc.finly.global.util.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +18,7 @@ public class MyPageServiceImpl implements MyPageService{
     // MyPage 관련 서비스
 
     private final MemberPersonaResultRepository memberPersonaResultRepository;
+    private final MemberRepository memberRepository;
 
     // 내 페르소나 조회
     @Override
@@ -23,5 +26,14 @@ public class MyPageServiceImpl implements MyPageService{
         return memberPersonaResultRepository.findByMemberIdFetchPersona(memberId)
                 .map(MyPagePersonaRes::from)
                 .orElseThrow(()-> new CustomException(MemberErrorCode.PERSONA_RESULT_NOT_FOUND));
+    }
+
+    // 내 프로필 조회
+    @Override
+    public MyPageMeRes getMyInfo(Long memberId){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()-> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        return MyPageMeRes.from(member);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #59 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
-  내 프로필 조회 기능 구현 


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
<img width="1296" height="678" alt="image" src="https://github.com/user-attachments/assets/ba3f979a-6321-4ff7-b7a6-f3c0305f3ddb" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자가 자신의 프로필(회원 ID, 이메일, 닉네임)을 조회할 수 있는 신규 API 추가

* **버그 수정**
  * 인증 정보 누락 시 접근 차단 처리(권한 검증 강화)
  * 존재하지 않는 회원 조회 시 명확한 오류 응답 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->