### PR TITLE
[Hotfix] prod 용 쿠키 설정 변경

### DIFF
--- a/src/main/java/com/umc/finly/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/finly/domain/auth/controller/AuthController.java
@@ -16,7 +16,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,10 +29,6 @@ public class AuthController {
     private final AuthService authService;
 
     private final CookieUtil cookieUtil;
-
-    // 로컬이라 false로 값 부여. 운영 단계에서 true로 키면 됨
-    @Value("${app.cookie.secure:false}")
-    private boolean cookieSecure;
 
     // 이메일 중복 확인
     @GetMapping("/check-email")
@@ -73,8 +68,7 @@ public class AuthController {
         cookieUtil.addRefreshTokenCookie(
                 response,
                 tokens.refreshToken(),
-                tokens.refreshMaxAgeSeconds(),
-                cookieSecure
+                tokens.refreshMaxAgeSeconds()
         );
 
         return ApiResponse.onSuccess(tokens.body(), SuccessCode.OK);

--- a/src/main/java/com/umc/finly/global/config/CookieProperties.java
+++ b/src/main/java/com/umc/finly/global/config/CookieProperties.java
@@ -15,4 +15,6 @@ public class CookieProperties {
      * HTTPS 환경에서만 true
      */
     private boolean secure = false;
+    private String sameSite = "Lax";
+    private String path = "/auth";
 }

--- a/src/main/java/com/umc/finly/global/config/CookieProperties.java
+++ b/src/main/java/com/umc/finly/global/config/CookieProperties.java
@@ -1,0 +1,18 @@
+package com.umc.finly.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.cookie")
+public class CookieProperties {
+
+    /**
+     * HTTPS 환경에서만 true
+     */
+    private boolean secure = false;
+}

--- a/src/main/java/com/umc/finly/global/util/CookieUtil.java
+++ b/src/main/java/com/umc/finly/global/util/CookieUtil.java
@@ -1,22 +1,26 @@
 package com.umc.finly.global.util;
 
+import com.umc.finly.global.config.CookieProperties;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class CookieUtil {
 
-    // 운영 환경에서 Secure=true 권장 (HTTPS)
+    private final CookieProperties cookieProperties;
+
     public void addRefreshTokenCookie(HttpServletResponse response,
                                       String refreshToken,
-                                      long maxAgeSeconds,
-                                      boolean secure){
+                                      long maxAgeSeconds) {
+
         ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
-                .secure(secure)
-                .path("/auth")
-                .sameSite("Lax")
+                .secure(cookieProperties.isSecure())
+                .path(cookieProperties.getPath())
+                .sameSite(cookieProperties.getSameSite())
                 .maxAge(maxAgeSeconds)
                 .build();
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -20,3 +20,5 @@ app:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS}
   cookie:
     secure: true
+    same-site: Lax   # 프론트/백 분리면 None
+    path: /auth

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,3 +18,5 @@ spring:
 app:
   cors:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS}
+  cookie:
+    secure: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,4 +38,7 @@ app:
   cors:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS}
   cookie:
-    secure: false
+    cookie:
+      secure: false
+      same-site: Lax
+      path: /auth

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,5 @@ openai:
 app:
   cors:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS}
+  cookie:
+    secure: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,7 +38,6 @@ app:
   cors:
     allowed-origins: ${APP_CORS_ALLOWED_ORIGINS}
   cookie:
-    cookie:
-      secure: false
-      same-site: Lax
-      path: /auth
+    secure: false
+    same-site: Lax
+    path: /auth


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #66 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- auth 쪽 JWT cookie 설정 변경


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선사항**
  * 인증용 쿠키 설정을 중앙에서 관리하도록 변경해 보안 정책 일관성 및 유지보수성 향상
  * 로그인 시 리프레시 토큰 쿠키 생성 방식이 구성값을 사용하도록 개선

* **구성 변경**
  * 앱 설정에 쿠키 관련 항목(app.cookie.secure, app.cookie.sameSite, app.cookie.path) 추가 — 환경별(프로덕션/개발) 값 분리 가능
<!-- end of auto-generated comment: release notes by coderabbit.ai -->