### PR TITLE
[Feat] 프로필 닉네임 변경 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
@@ -1,18 +1,19 @@
 package com.umc.finly.domain.member.controller;
 
 import com.umc.finly.domain.auth.exception.AuthErrorCode;
+import com.umc.finly.domain.member.dto.request.UpdateNicknameReq;
 import com.umc.finly.domain.member.dto.response.MyPageMeRes;
 import com.umc.finly.domain.member.dto.response.MyPagePersonaRes;
+import com.umc.finly.domain.member.dto.response.UpdateNicknameRes;
 import com.umc.finly.domain.member.service.MyPageService;
 import com.umc.finly.global.apiPayload.exception.CustomException;
 import com.umc.finly.global.apiPayload.response.ApiResponse;
 import com.umc.finly.global.apiPayload.response.SuccessCode;
 import com.umc.finly.global.config.security.AuthPrincipal;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -46,6 +47,21 @@ public class MyPageController {
 
         return ApiResponse.onSuccess(
                 myPageService.getMyInfo(principal.getMemberId()),
+                SuccessCode.OK
+        );
+    }
+
+    // 내 닉네임 변경
+    @PostMapping("/me/nickname")
+    public ApiResponse<UpdateNicknameRes> updateNickname(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @RequestBody @Valid UpdateNicknameReq request
+            ){
+        return ApiResponse.onSuccess(
+                myPageService.updateMyNickname(
+                        principal.getMemberId(),
+                        request.getNickname()
+                ),
                 SuccessCode.OK
         );
     }

--- a/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
@@ -57,6 +57,11 @@ public class MyPageController {
             @AuthenticationPrincipal AuthPrincipal principal,
             @RequestBody @Valid UpdateNicknameReq request
             ){
+
+        if (principal == null){
+            throw new CustomException(AuthErrorCode.UNAUTHORIZED);
+        }
+
         return ApiResponse.onSuccess(
                 myPageService.updateMyNickname(
                         principal.getMemberId(),

--- a/src/main/java/com/umc/finly/domain/member/dto/request/UpdateNicknameReq.java
+++ b/src/main/java/com/umc/finly/domain/member/dto/request/UpdateNicknameReq.java
@@ -1,0 +1,12 @@
+package com.umc.finly.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UpdateNicknameReq {
+    @NotBlank(message = "닉네임은 비어 있을 수 없습니다.")
+    @Size(max = 50, message = "닉네임은 최대 50자까지 가능합니다.")
+    private String nickname;
+}

--- a/src/main/java/com/umc/finly/domain/member/dto/response/UpdateNicknameRes.java
+++ b/src/main/java/com/umc/finly/domain/member/dto/response/UpdateNicknameRes.java
@@ -1,0 +1,19 @@
+package com.umc.finly.domain.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UpdateNicknameRes {
+
+    private String nickname;
+
+    public static UpdateNicknameRes of(String nickname){
+        return UpdateNicknameRes.builder()
+                .nickname(nickname)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/finly/domain/member/entity/Member.java
@@ -59,5 +59,9 @@ public class Member extends CreatedDeletedBaseEntity {
         this.refreshToken = null;
         this.refreshTokenExpiredAt = null;
     }
+
+    public void changeNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }
 

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageService.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageService.java
@@ -2,9 +2,13 @@ package com.umc.finly.domain.member.service;
 
 import com.umc.finly.domain.member.dto.response.MyPageMeRes;
 import com.umc.finly.domain.member.dto.response.MyPagePersonaRes;
+import com.umc.finly.domain.member.dto.response.UpdateNicknameRes;
 
 public interface MyPageService {
+    // 내 페르소나 조회
     MyPagePersonaRes getMyPersona(Long memberId);
-
+    // 내 프로필 정보 조회
     MyPageMeRes getMyInfo(Long memberId);
+    // 내 닉네임 변경
+    UpdateNicknameRes updateMyNickname(Long memberId, String nickname);
 }

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
@@ -40,6 +40,7 @@ public class MyPageServiceImpl implements MyPageService{
 
     // 내 닉네임 변경
     @Override
+    @Transactional
     public UpdateNicknameRes updateMyNickname(Long memberId, String nickname){
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(()-> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
@@ -2,6 +2,7 @@ package com.umc.finly.domain.member.service;
 
 import com.umc.finly.domain.member.dto.response.MyPageMeRes;
 import com.umc.finly.domain.member.dto.response.MyPagePersonaRes;
+import com.umc.finly.domain.member.dto.response.UpdateNicknameRes;
 import com.umc.finly.domain.member.entity.Member;
 import com.umc.finly.domain.member.exception.MemberErrorCode;
 import com.umc.finly.domain.member.repository.MemberPersonaResultRepository;
@@ -35,5 +36,21 @@ public class MyPageServiceImpl implements MyPageService{
                 .orElseThrow(()-> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         return MyPageMeRes.from(member);
+    }
+
+    // 내 닉네임 변경
+    @Override
+    public UpdateNicknameRes updateMyNickname(Long memberId, String nickname){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()-> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 닉네임 변경 없을 시
+        if (member.getNickname().equals(nickname)){
+            return UpdateNicknameRes.of(member.getNickname());
+        }
+
+        member.changeNickname(nickname);
+
+        return UpdateNicknameRes.of(member.getNickname());
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #63 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 내 닉네임 변경 서비스 구현


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

### 닉네임 변경 전 내 프로필 조회 
<img width="1356" height="688" alt="image" src="https://github.com/user-attachments/assets/9cf166cb-0d51-4523-ac49-405f15756d5b" />

### 닉네임 변경 
<img width="962" height="690" alt="image" src="https://github.com/user-attachments/assets/abeea9a4-b150-4535-9a91-4fd88c60cf52" />
<img width="1384" height="626" alt="image" src="https://github.com/user-attachments/assets/01754e67-f527-4e89-ac44-781502d2475e" />

### 닉네임 변경 후 내 프로필 조회 
<img width="1284" height="712" alt="image" src="https://github.com/user-attachments/assets/a2129fd6-19c3-4b3c-80f7-a8008b096cdc" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 마이페이지에서 닉네임을 변경할 수 있는 기능이 추가되었습니다.
  * 닉네임은 비어있을 수 없으며 최대 50자 이내로 검증됩니다.
  * 인증된 사용자만 닉네임을 수정할 수 있으며, 변경 시 즉시 업데이트된 닉네임이 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->