### PR TITLE
[Feat] 해당 날짜 마음 조각 조회

### DIFF
--- a/src/main/java/com/umc/finly/domain/record/controller/RecordController.java
+++ b/src/main/java/com/umc/finly/domain/record/controller/RecordController.java
@@ -7,6 +7,7 @@ import com.umc.finly.domain.record.dto.RecordDetailRes;
 import com.umc.finly.domain.record.dto.RecordFeedbackRes;
 import com.umc.finly.domain.record.dto.RecordUpdateReq;
 import com.umc.finly.domain.record.dto.RecordUpdateRes;
+import com.umc.finly.domain.record.dto.TodayRecordRes;
 import com.umc.finly.domain.record.service.RecordFeedbackService;
 import com.umc.finly.domain.record.service.RecordService;
 import com.umc.finly.global.apiPayload.response.ApiResponse;
@@ -14,8 +15,11 @@ import com.umc.finly.global.apiPayload.response.SuccessCode;
 import com.umc.finly.global.config.security.AuthPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,6 +36,15 @@ public class RecordController {
     ) {
         RecordCreateRes result = recordService.createRecord(principal.getMemberId(), request);
         return ApiResponse.onSuccess(result, SuccessCode.CREATED);
+    }
+
+    @GetMapping("/today")
+    public ApiResponse<TodayRecordRes> getTodayRecords(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        TodayRecordRes result = recordService.getTodayRecords(principal.getMemberId(), date);
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
     }
 
     @GetMapping("/{recordId}")

--- a/src/main/java/com/umc/finly/domain/record/dto/TodayRecordRes.java
+++ b/src/main/java/com/umc/finly/domain/record/dto/TodayRecordRes.java
@@ -1,0 +1,76 @@
+package com.umc.finly.domain.record.dto;
+
+import com.umc.finly.domain.record.entity.RecordEntry;
+import com.umc.finly.domain.record.enums.EmotionCode;
+import com.umc.finly.domain.record.enums.Session;
+import com.umc.finly.domain.record.enums.TradeAction;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class TodayRecordRes {
+
+    private LocalDate date;
+    private PrismFeedback prismFeedback;
+    private List<TimelineEntry> timelineSummary;
+    private boolean hasRecords;
+    private int recordCount;
+
+    @Getter
+    @Builder
+    public static class PrismFeedback {
+        private String title;
+        private LocalDateTime generatedAt;
+    }
+
+    @Getter
+    @Builder
+    public static class TimelineEntry {
+        private Long recordId;
+        private LocalDate recordDate;
+        private LocalDateTime recordedAt;
+        private Session session;
+        private TradeAction tradeAction;
+        private String symbol;
+        private BigDecimal unitPrice;
+        private BigDecimal quantity;
+        private EmotionCode emotionCode;
+        private Integer emotionIntensity;
+        private String memo;
+
+        public static TimelineEntry from(RecordEntry entry, String symbol) {
+            return TimelineEntry.builder()
+                    .recordId(entry.getId())
+                    .recordDate(entry.getRecordDate())
+                    .recordedAt(entry.getCreatedAt())
+                    .session(entry.getSession())
+                    .tradeAction(entry.getTradeAction())
+                    .symbol(symbol)
+                    .unitPrice(entry.getUnitPrice())
+                    .quantity(entry.getQuantity())
+                    .emotionCode(entry.getEmotionCode())
+                    .emotionIntensity(entry.getEmotionIntensity())
+                    .memo(entry.getMemo())
+                    .build();
+        }
+    }
+
+    public static String generatePrismTitle(List<RecordEntry> entries) {
+        if (entries.isEmpty()) {
+            return "괜찮아요. 기록이 없는 날도 있을 수 있죠.";
+        }
+        if (entries.size() == 1) {
+            EmotionCode emotion = entries.get(0).getEmotionCode();
+            return "{{" + emotion.getLabel() + "}}한 하루네요!";
+        }
+        EmotionCode first = entries.get(0).getEmotionCode();
+        EmotionCode last = entries.get(entries.size() - 1).getEmotionCode();
+        return "{{" + first.getLabel() + "}}하게 시작해 {{" + last.getLabel() + "}}" + last.getParticle() + " 마무리한 날이네요.";
+    }
+}

--- a/src/main/java/com/umc/finly/domain/record/enums/EmotionCode.java
+++ b/src/main/java/com/umc/finly/domain/record/enums/EmotionCode.java
@@ -9,7 +9,7 @@ public enum EmotionCode {
     CALM("평온", "으로"),
     ANXIETY("불안", "으로"),
     REGRET("후회", "로"),
-    GREED("욕심", "으로"),
+    GREED("탐욕", "으로"),
     CONFIDENCE("확신", "으로");
 
     private final String label;

--- a/src/main/java/com/umc/finly/domain/record/enums/EmotionCode.java
+++ b/src/main/java/com/umc/finly/domain/record/enums/EmotionCode.java
@@ -1,9 +1,17 @@
 package com.umc.finly.domain.record.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum EmotionCode {
-    CALM,
-    ANXIETY,
-    REGRET,
-    GREED,
-    CONFIDENCE
+    CALM("평온", "으로"),
+    ANXIETY("불안", "으로"),
+    REGRET("후회", "로"),
+    GREED("욕심", "으로"),
+    CONFIDENCE("확신", "으로");
+
+    private final String label;
+    private final String particle;
 }

--- a/src/main/java/com/umc/finly/domain/record/repository/RecordEntryRepository.java
+++ b/src/main/java/com/umc/finly/domain/record/repository/RecordEntryRepository.java
@@ -4,9 +4,11 @@ import com.umc.finly.domain.record.entity.RecordEntry;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface RecordEntryRepository extends JpaRepository<RecordEntry, Long> {
     boolean existsByClientRequestId(String clientRequestId);
     List<RecordEntry> findByMemberIdOrderByRecordDateDesc(Long memberId, Pageable pageable);
+    List<RecordEntry> findByMemberIdAndRecordDateOrderByCreatedAtAsc(Long memberId, LocalDate recordDate);
 }

--- a/src/main/java/com/umc/finly/domain/record/service/RecordService.java
+++ b/src/main/java/com/umc/finly/domain/record/service/RecordService.java
@@ -6,10 +6,14 @@ import com.umc.finly.domain.record.dto.RecordCreateRes;
 import com.umc.finly.domain.record.dto.RecordDetailRes;
 import com.umc.finly.domain.record.dto.RecordUpdateReq;
 import com.umc.finly.domain.record.dto.RecordUpdateRes;
+import com.umc.finly.domain.record.dto.TodayRecordRes;
+
+import java.time.LocalDate;
 
 public interface RecordService {
     RecordCreateRes createRecord(Long memberId, RecordCreateReq request);
     RecordDetailRes getRecord(Long memberId, Long recordId);
     RecordUpdateRes updateRecord(Long memberId, Long recordId, RecordUpdateReq request);
     DailyReportRes getDailyReport(Long memberId, Long recordId);
+    TodayRecordRes getTodayRecords(Long memberId, LocalDate date);
 }

--- a/src/main/java/com/umc/finly/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/record/service/RecordServiceImpl.java
@@ -8,6 +8,7 @@ import com.umc.finly.domain.record.dto.RecordCreateRes;
 import com.umc.finly.domain.record.dto.RecordDetailRes;
 import com.umc.finly.domain.record.dto.RecordUpdateReq;
 import com.umc.finly.domain.record.dto.RecordUpdateRes;
+import com.umc.finly.domain.record.dto.TodayRecordRes;
 import com.umc.finly.domain.record.infra.OpenAiFeedbackClient;
 import com.umc.finly.domain.record.entity.RecordEntry;
 import com.umc.finly.domain.record.entity.RecordFeedback;
@@ -23,7 +24,13 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -201,5 +208,44 @@ public class RecordServiceImpl implements RecordService {
         }
 
         return DailyReportRes.from(entry, stock, content);
+    }
+
+    @Override
+    public TodayRecordRes getTodayRecords(Long memberId, LocalDate date) {
+        // 1. 해당 날짜의 기록 조회 (createdAt 오름차순)
+        List<RecordEntry> entries = recordEntryRepository
+                .findByMemberIdAndRecordDateOrderByCreatedAtAsc(memberId, date);
+
+        // 2. PrismFeedback 타이틀 생성
+        String title = TodayRecordRes.generatePrismTitle(entries);
+        TodayRecordRes.PrismFeedback prismFeedback = TodayRecordRes.PrismFeedback.builder()
+                .title(title)
+                .generatedAt(LocalDateTime.now())
+                .build();
+
+        // 3. 기록에 포함된 stockId 일괄 조회
+        List<Long> stockIds = entries.stream()
+                .map(RecordEntry::getStockId)
+                .distinct()
+                .toList();
+        Map<Long, Stock> stockMap = stockRepository.findAllById(stockIds).stream()
+                .collect(Collectors.toMap(Stock::getId, Function.identity()));
+
+        // 4. TimelineEntry 변환
+        List<TodayRecordRes.TimelineEntry> timelineSummary = entries.stream()
+                .map(entry -> {
+                    Stock stock = stockMap.get(entry.getStockId());
+                    String symbol = stock != null ? stock.getSymbol() : "";
+                    return TodayRecordRes.TimelineEntry.from(entry, symbol);
+                })
+                .toList();
+
+        return TodayRecordRes.builder()
+                .date(date)
+                .prismFeedback(prismFeedback)
+                .timelineSummary(timelineSummary)
+                .hasRecords(!entries.isEmpty())
+                .recordCount(entries.size())
+                .build();
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #31 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 해당 날짜의 모든 기록 조회 및 감정 요약 타이

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

[마음 조각 리스트 조회 (GET /api/records/today)](https://www.notion.so/_-2f2b7acc900f80c5b8e4df72325693d2#2fcb7acc900f80bd8ae2cfb3bb15dadc)

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 특정 날짜의 거래 기록을 조회하는 신규 API가 추가되어 날짜별 내역 확인이 가능합니다.
  * 조회 결과에 감정 피드백(요약 문구 및 생성 시각)과 상세 거래 타임라인(심볼, 가격, 수량 등)이 포함됩니다.
  * 감정 코드가 레이블과 표현(조사) 정보를 포함하도록 개선되어 감정 표시가 더 자연스러워졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->