### PR TITLE
[Feat] 토큰 재발급

### DIFF
--- a/src/main/java/com/umc/finly/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/finly/domain/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.umc.finly.domain.auth.controller;
 import com.umc.finly.domain.auth.dto.req.AuthLoginReq;
 import com.umc.finly.domain.auth.dto.req.AuthSignUpReq;
 import com.umc.finly.domain.auth.dto.res.AuthLoginRes;
+import com.umc.finly.domain.auth.dto.res.AuthReissueRes;
 import com.umc.finly.domain.auth.dto.res.AuthSignUpRes;
 import com.umc.finly.domain.auth.dto.res.CheckEmailRes;
 import com.umc.finly.domain.auth.exception.AuthErrorCode;
@@ -72,5 +73,20 @@ public class AuthController {
         );
 
         return ApiResponse.onSuccess(tokens.body(), SuccessCode.OK);
+    }
+
+    // 토큰 재발급
+    @PostMapping("/reissue")
+    public ApiResponse<AuthReissueRes> reissue(
+            @CookieValue(value = "refreshToken", required = false) String refreshToken,
+            HttpServletResponse response
+    ){
+        AuthService.ReissueTokens tokens = authService.reissue(refreshToken);
+        cookieUtil.addRefreshTokenCookie(response, tokens.refreshToken(), tokens.refreshMaxAgeSeconds());
+
+        return ApiResponse.onSuccess(
+                AuthReissueRes.of(tokens.accessToken()),
+                SuccessCode.OK
+        );
     }
 }

--- a/src/main/java/com/umc/finly/domain/auth/dto/res/AuthReissueRes.java
+++ b/src/main/java/com/umc/finly/domain/auth/dto/res/AuthReissueRes.java
@@ -1,0 +1,19 @@
+package com.umc.finly.domain.auth.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AuthReissueRes {
+
+    private String accessToken;
+
+    public static AuthReissueRes of(String accessToken){
+        return AuthReissueRes.builder()
+                .accessToken(accessToken)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
@@ -18,14 +18,13 @@ public enum AuthErrorCode implements BaseCode {
 
     // 401
     INVALID_LOGIN_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH401_1", "이메일 또는 비밀번호가 올바르지 않습니다."),
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH401_2", "인증이 필요합니다. "),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH401_2", "인증이 필요합니다."),
     ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_3", "액세스 토큰이 만료되었습니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_4", "유효하지 않은 액세스 토큰입니다."),
-
     REFRESH_TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "AUTH401_5", "refreshToken 쿠키가 없습니다."),
-    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_6", "refreshToken 이 만료되었습니다."),
-    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_7", "유효하지 않은 refreshToken 입니다."),
-    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH401_8", "서버에 저장된 refreshToken 과 일치하지 않습니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_6", "refreshToken이 만료되었습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_7", "유효하지 않은 refreshToken입니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH401_8", "서버에 저장된 refreshToken과 일치하지 않습니다."),
 
     //403
     FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH403", "접근 권한이 없습니다."),

--- a/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
@@ -17,11 +17,15 @@ public enum AuthErrorCode implements BaseCode {
     INVALID_PERSONA_ANSWERS(HttpStatus.BAD_REQUEST, "AUTH400_4", "페르소나 답변이 올바르지 않습니다."),
 
     // 401
-    INVALID_LOGIN_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH401", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    INVALID_LOGIN_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH401_1", "이메일 또는 비밀번호가 올바르지 않습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH401_2", "인증이 필요합니다. "),
+    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_3", "액세스 토큰이 만료되었습니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_4", "유효하지 않은 액세스 토큰입니다."),
 
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH401_1", "인증이 필요합니다. "),
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_2", "토큰이 만료되었습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_3", "유효하지 않은 토큰입니다."),
+    REFRESH_TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "AUTH401_5", "refreshToken 쿠키가 없습니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH401_6", "refreshToken 이 만료되었습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_7", "유효하지 않은 refreshToken 입니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH401_8", "서버에 저장된 refreshToken 과 일치하지 않습니다."),
 
     //403
     FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH403", "접근 권한이 없습니다."),

--- a/src/main/java/com/umc/finly/domain/auth/service/AuthService.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/AuthService.java
@@ -12,9 +12,17 @@ public interface AuthService {
 
     LoginTokens login(AuthLoginReq request);
 
+    ReissueTokens reissue(String refreshToken);
+
     record LoginTokens(
             AuthLoginRes body,
             String refreshToken,
             long refreshMaxAgeSeconds
     ){}
+
+    record ReissueTokens(
+            String accessToken,
+            String refreshToken,
+            long refreshMaxAgeSeconds
+    ) {}
 }

--- a/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
@@ -157,41 +157,51 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public ReissueTokens reissue(String refreshToken) {
 
-        if (refreshToken == null || refreshToken.isBlank()) {
+        // 0) refreshToken 존재 체크 + 정규화
+        if (refreshToken == null) {
             throw new CustomException(AuthErrorCode.REFRESH_TOKEN_MISSING);
         }
 
-        // 1) refresh 토큰 1차 검증 (서명/만료/type)
-        try {
-            jwtProvider.assertRefreshToken(refreshToken);
-        } catch (ExpiredJwtException e) {
-            throw new CustomException(AuthErrorCode.REFRESH_TOKEN_EXPIRED); // 또는 TOKEN_EXPIRED 정책에 맞게
-        } catch (JwtException | IllegalArgumentException e) {
-            throw new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        String rawRefreshToken = refreshToken.trim();
+        while (rawRefreshToken.startsWith("Bearer ")) {
+            rawRefreshToken = rawRefreshToken.substring(7).trim();
+        }
+        if (rawRefreshToken.isBlank()) {
+            throw new CustomException(AuthErrorCode.REFRESH_TOKEN_MISSING);
         }
 
-        // 2) memberId/email 추출
-        Long memberId;
+        // 1) refresh 토큰 1차 검증 (서명/만료/type=refresh) + 만료/무효 매핑
         try {
-            jwtProvider.assertRefreshToken(refreshToken);
-            memberId = jwtProvider.getMemberId(refreshToken);
+            jwtProvider.assertRefreshToken(rawRefreshToken);
         } catch (ExpiredJwtException e) {
             throw new CustomException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
         } catch (JwtException | IllegalArgumentException e) {
             throw new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
+        // 2) memberId 추출
+        final Long memberId;
+        try {
+            memberId = jwtProvider.getMemberId(rawRefreshToken);
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // 3) Member 조회 + 최신 email 사용
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+
         String email = member.getEmail();
 
-        // 3) DB 만료 검증 (서버 저장 만료 시각)
+        // 4) DB 만료 검증 (서버 저장 만료 시각)
         LocalDateTime expiredAt = member.getRefreshTokenExpiredAt();
         if (expiredAt == null || !expiredAt.isAfter(LocalDateTime.now())) {
             throw new CustomException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
         }
 
-        // 4) 새 토큰 발급
+        // 5) 새 토큰 발급
         String newAccessToken = jwtProvider.createAccessToken(memberId, email);
 
         String newRefreshToken = jwtProvider.createRefreshToken(memberId, email);
@@ -200,11 +210,11 @@ public class AuthServiceImpl implements AuthService {
                 ZoneId.systemDefault()
         );
 
-        // 5) CAS로 refreshToken 회전 (경쟁 조건 차단)
+        // 6) CAS로 refreshToken 회전 (경쟁 조건 차단)
         int updated = memberRepository.rotateRefreshToken(
                 memberId,
-                refreshToken,          // old token
-                newRefreshToken,       // new token
+                rawRefreshToken,     // old token
+                newRefreshToken,     // new token
                 newRefreshExpiredAt
         );
 

--- a/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
@@ -13,7 +13,6 @@ import com.umc.finly.domain.member.dto.request.PersonaAnswerReq;
 import com.umc.finly.domain.member.entity.Member;
 import com.umc.finly.domain.member.entity.Persona;
 import com.umc.finly.domain.member.entity.mapping.MembersPersonasResult;
-import com.umc.finly.domain.member.exception.MemberErrorCode;
 import com.umc.finly.domain.member.repository.MemberPersonaResultRepository;
 import com.umc.finly.domain.member.repository.MemberRepository;
 import com.umc.finly.domain.member.repository.MemberTermRepository;
@@ -150,6 +149,61 @@ public class AuthServiceImpl implements AuthService {
         );
 
         return new LoginTokens(result, refreshToken, refreshMaxAgeSeconds);
+    }
+
+    /** 토큰 재발급 **/
+    @Override
+    public ReissueTokens reissue(String refreshToken){
+
+        if (refreshToken == null || refreshToken.isBlank()){
+            throw new CustomException(AuthErrorCode.REFRESH_TOKEN_MISSING);
+        }
+
+        // 1) refresh 토큰 1차 검증 : 서명/만료
+        if (!jwtProvider.validateRefreshToken(refreshToken)){
+            throw new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // 2) type = refresh 확인
+        String type = jwtProvider.getType(refreshToken);
+        if (!"refresh".equals(type)) {
+            throw new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // 3) memberId/email 추출
+        Long memberId = jwtProvider.getMemberId(refreshToken);
+        String email = jwtProvider.getEmail(refreshToken);
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+
+        // 4) DB 검증
+        if (member.getRefreshToken() == null || !member.getRefreshToken().equals(refreshToken)) {
+            throw new CustomException(AuthErrorCode.REFRESH_TOKEN_MISMATCH);
+        }
+
+        LocalDateTime expiredAt = member.getRefreshTokenExpiredAt();
+        if (expiredAt == null || expiredAt.isBefore(LocalDateTime.now()) || expiredAt.isEqual(LocalDateTime.now())) {
+            throw new CustomException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
+        }
+
+        // 5) 새 accessToken 발급
+        String newAccessToken = jwtProvider.createAccessToken(memberId, email);
+
+        String newRefreshToken = jwtProvider.createRefreshToken(memberId, email);
+        LocalDateTime newRefreshExpiredAt = LocalDateTime.ofInstant(
+                jwtProvider.getExpiration(newRefreshToken).toInstant(),
+                ZoneId.systemDefault()
+        );
+        member.updateRefreshToken(newRefreshToken, newRefreshExpiredAt);
+        memberRepository.save(member);
+
+        long refreshMaxAgeSeconds = Math.max(
+                0,
+                (jwtProvider.getExpiration(newRefreshToken).getTime() - System.currentTimeMillis()) / 1000
+        );
+
+        return new ReissueTokens(newAccessToken, newRefreshToken, refreshMaxAgeSeconds);
     }
 
     // -----------------------------------------------------------

--- a/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
@@ -19,6 +19,8 @@ import com.umc.finly.domain.member.repository.MemberTermRepository;
 import com.umc.finly.domain.member.service.PersonaScoringService;
 import com.umc.finly.global.apiPayload.exception.CustomException;
 import com.umc.finly.global.infra.jwt.JwtProvider;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -153,41 +155,43 @@ public class AuthServiceImpl implements AuthService {
 
     /** 토큰 재발급 **/
     @Override
-    public ReissueTokens reissue(String refreshToken){
+    public ReissueTokens reissue(String refreshToken) {
 
-        if (refreshToken == null || refreshToken.isBlank()){
+        if (refreshToken == null || refreshToken.isBlank()) {
             throw new CustomException(AuthErrorCode.REFRESH_TOKEN_MISSING);
         }
 
-        // 1) refresh 토큰 1차 검증 : 서명/만료
-        if (!jwtProvider.validateRefreshToken(refreshToken)){
+        // 1) refresh 토큰 1차 검증 (서명/만료/type)
+        try {
+            jwtProvider.assertRefreshToken(refreshToken);
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(AuthErrorCode.REFRESH_TOKEN_EXPIRED); // 또는 TOKEN_EXPIRED 정책에 맞게
+        } catch (JwtException | IllegalArgumentException e) {
             throw new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        // 2) type = refresh 확인
-        String type = jwtProvider.getType(refreshToken);
-        if (!"refresh".equals(type)) {
+        // 2) memberId/email 추출
+        Long memberId;
+        String email;
+        try {
+            memberId = jwtProvider.getMemberId(refreshToken);
+            email = jwtProvider.getEmail(refreshToken);
+        } catch (ExpiredJwtException e) {
+            throw new CustomException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
+        } catch (JwtException | IllegalArgumentException e) {
             throw new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
-
-        // 3) memberId/email 추출
-        Long memberId = jwtProvider.getMemberId(refreshToken);
-        String email = jwtProvider.getEmail(refreshToken);
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN));
 
-        // 4) DB 검증
-        if (member.getRefreshToken() == null || !member.getRefreshToken().equals(refreshToken)) {
-            throw new CustomException(AuthErrorCode.REFRESH_TOKEN_MISMATCH);
-        }
-
+        // 3) DB 만료 검증 (서버 저장 만료 시각)
         LocalDateTime expiredAt = member.getRefreshTokenExpiredAt();
-        if (expiredAt == null || expiredAt.isBefore(LocalDateTime.now()) || expiredAt.isEqual(LocalDateTime.now())) {
+        if (expiredAt == null || !expiredAt.isAfter(LocalDateTime.now())) {
             throw new CustomException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
         }
 
-        // 5) 새 accessToken 발급
+        // 4) 새 토큰 발급
         String newAccessToken = jwtProvider.createAccessToken(memberId, email);
 
         String newRefreshToken = jwtProvider.createRefreshToken(memberId, email);
@@ -195,8 +199,19 @@ public class AuthServiceImpl implements AuthService {
                 jwtProvider.getExpiration(newRefreshToken).toInstant(),
                 ZoneId.systemDefault()
         );
-        member.updateRefreshToken(newRefreshToken, newRefreshExpiredAt);
-        memberRepository.save(member);
+
+        // 5) CAS로 refreshToken 회전 (경쟁 조건 차단)
+        int updated = memberRepository.rotateRefreshToken(
+                memberId,
+                refreshToken,          // old token
+                newRefreshToken,       // new token
+                newRefreshExpiredAt
+        );
+
+        if (updated == 0) {
+            // 동시에 다른 요청이 먼저 회전시켰거나, 서버 저장 토큰과 불일치
+            throw new CustomException(AuthErrorCode.REFRESH_TOKEN_MISMATCH);
+        }
 
         long refreshMaxAgeSeconds = Math.max(
                 0,
@@ -205,6 +220,7 @@ public class AuthServiceImpl implements AuthService {
 
         return new ReissueTokens(newAccessToken, newRefreshToken, refreshMaxAgeSeconds);
     }
+
 
     // -----------------------------------------------------------
     private boolean isValidPassword(String raw) {

--- a/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
@@ -172,10 +172,9 @@ public class AuthServiceImpl implements AuthService {
 
         // 2) memberId/email 추출
         Long memberId;
-        String email;
         try {
+            jwtProvider.assertRefreshToken(refreshToken);
             memberId = jwtProvider.getMemberId(refreshToken);
-            email = jwtProvider.getEmail(refreshToken);
         } catch (ExpiredJwtException e) {
             throw new CustomException(AuthErrorCode.REFRESH_TOKEN_EXPIRED);
         } catch (JwtException | IllegalArgumentException e) {
@@ -184,6 +183,7 @@ public class AuthServiceImpl implements AuthService {
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+        String email = member.getEmail();
 
         // 3) DB 만료 검증 (서버 저장 만료 시각)
         LocalDateTime expiredAt = member.getRefreshTokenExpiredAt();

--- a/src/main/java/com/umc/finly/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/finly/domain/member/repository/MemberRepository.java
@@ -21,6 +21,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
      where m.id = :memberId
        and m.refreshToken = :oldToken
 """)
-    int rotateRefreshToken(Long memberId, String oldToken, String newToken, LocalDateTime newExpiredAt);
+    int rotateRefreshToken(
+            @Param("memberId") Long memberId,
+            @Param("oldToken") String oldToken,
+            @Param("newToken") String newToken,
+            @Param("newExpiredAt") LocalDateTime newExpiredAt
+    );
 
 }

--- a/src/main/java/com/umc/finly/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/finly/domain/member/repository/MemberRepository.java
@@ -15,16 +15,12 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
-        update Member m
-           set m.refreshToken = :newToken,
-               m.refreshTokenExpiredAt = :newExpiredAt
-         where m.id = :memberId
-           and m.refreshToken = :oldToken
-    """)
-    int rotateRefreshToken(
-            @Param("memberId") Long memberId,
-            @Param("oldToken") String oldToken,
-            @Param("newToken") String newToken,
-            @Param("newExpiredAt") LocalDateTime newExpiredAt
-    );
+    update Member m
+       set m.refreshToken = :newToken,
+           m.refreshTokenExpiredAt = :newExpiredAt
+     where m.id = :memberId
+       and m.refreshToken = :oldToken
+""")
+    int rotateRefreshToken(Long memberId, String oldToken, String newToken, LocalDateTime newExpiredAt);
+
 }

--- a/src/main/java/com/umc/finly/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/finly/domain/member/repository/MemberRepository.java
@@ -2,10 +2,29 @@ package com.umc.finly.domain.member.repository;
 
 import com.umc.finly.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
     Optional<Member> findByEmail(String email);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update Member m
+           set m.refreshToken = :newToken,
+               m.refreshTokenExpiredAt = :newExpiredAt
+         where m.id = :memberId
+           and m.refreshToken = :oldToken
+    """)
+    int rotateRefreshToken(
+            @Param("memberId") Long memberId,
+            @Param("oldToken") String oldToken,
+            @Param("newToken") String newToken,
+            @Param("newExpiredAt") LocalDateTime newExpiredAt
+    );
 }

--- a/src/main/java/com/umc/finly/global/infra/jwt/JwtProvider.java
+++ b/src/main/java/com/umc/finly/global/infra/jwt/JwtProvider.java
@@ -1,6 +1,7 @@
 package com.umc.finly.global.infra.jwt;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -69,6 +70,14 @@ public class JwtProvider {
 
     public Date getExpiration(String token) {
         return parseClaims(token).getExpiration();
+    }
+
+    public void assertRefreshToken(String token) throws ExpiredJwtException, JwtException {
+        Claims claims = parseClaims(token); // 여기서 만료/무효 예외 그대로 올라감
+        String type = claims.get("type", String.class);
+        if (!"refresh".equals(type)) {
+            throw new JwtException("Not a refresh token");
+        }
     }
 
     private String buildToken(Long memberId, String email, String type, long expireMs) {

--- a/src/main/java/com/umc/finly/global/infra/jwt/JwtProvider.java
+++ b/src/main/java/com/umc/finly/global/infra/jwt/JwtProvider.java
@@ -111,4 +111,9 @@ public class JwtProvider {
         }
         return raw;
     }
+
+    public String normalize(String token) {
+        return resolveToken(token);
+    }
+
 }

--- a/src/main/java/com/umc/finly/global/infra/jwt/JwtProvider.java
+++ b/src/main/java/com/umc/finly/global/infra/jwt/JwtProvider.java
@@ -14,7 +14,6 @@ import java.util.Date;
 
 @Component
 public class JwtProvider {
-    // 토큰 생성 / 파싱 / 검증
 
     private final SecretKey secretKey;
     private final long accessTokenExpireMs;
@@ -30,36 +29,24 @@ public class JwtProvider {
         this.refreshTokenExpireMs = refreshTokenExpireMs;
     }
 
-    // token 생성
     public String createAccessToken(Long memberId, String email) {
         return buildToken(memberId, email, "access", accessTokenExpireMs);
     }
 
-    public String createRefreshToken(Long memberId, String email){
+    public String createRefreshToken(Long memberId, String email) {
         return buildToken(memberId, email, "refresh", refreshTokenExpireMs);
     }
 
-    // 토큰에서 추출
     public Long getMemberId(String token) {
         return parseClaims(token).get("memberId", Long.class);
     }
+
     public String getEmail(String token) {
         return parseClaims(token).get("email", String.class);
     }
-    public String getType(String token) { return parseClaims(token).get("type", String.class);
-    }
-    public String getTokenType(String token) {
-        return parseClaims(token).get("type", String.class);
-    }
 
-    // 서명/만료 등 기본 검증
-    public boolean validate(String token) {
-        try {
-            parseClaims(token);
-            return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            return false;
-        }
+    public String getType(String token) {
+        return parseClaims(token).get("type", String.class);
     }
 
     public boolean validateAccessToken(String token) {
@@ -80,7 +67,6 @@ public class JwtProvider {
         }
     }
 
-    // 만료시간 변환 (디버깅/로직에 사용)
     public Date getExpiration(String token) {
         return parseClaims(token).getExpiration();
     }
@@ -90,7 +76,7 @@ public class JwtProvider {
         return Jwts.builder()
                 .claim("memberId", memberId)
                 .claim("email", email)
-                .claim("type", type)    // access | refresh
+                .claim("type", type)
                 .setIssuedAt(new Date(now))
                 .setExpiration(new Date(now + expireMs))
                 .signWith(secretKey, SignatureAlgorithm.HS256)
@@ -109,9 +95,11 @@ public class JwtProvider {
 
     private String resolveToken(String token) {
         if (token == null) return null;
-        if (token.startsWith("Bearer ")) {
-            return token.substring(7);
+
+        String raw = token.trim();
+        while (raw.startsWith("Bearer ")) {
+            raw = raw.substring(7).trim();
         }
-        return token;
+        return raw;
     }
 }

--- a/src/main/java/com/umc/finly/global/infra/jwt/JwtProvider.java
+++ b/src/main/java/com/umc/finly/global/infra/jwt/JwtProvider.java
@@ -46,6 +46,8 @@ public class JwtProvider {
     public String getEmail(String token) {
         return parseClaims(token).get("email", String.class);
     }
+    public String getType(String token) { return parseClaims(token).get("type", String.class);
+    }
     public String getTokenType(String token) {
         return parseClaims(token).get("type", String.class);
     }

--- a/src/main/java/com/umc/finly/global/util/CookieUtil.java
+++ b/src/main/java/com/umc/finly/global/util/CookieUtil.java
@@ -26,4 +26,17 @@ public class CookieUtil {
 
         response.addHeader("Set-Cookie", cookie.toString());
     }
+
+    // 로그아웃/강제삭제용
+    public void clearRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
+                .httpOnly(true)
+                .secure(cookieProperties.isSecure())
+                .path(cookieProperties.getPath())
+                .sameSite(cookieProperties.getSameSite())
+                .maxAge(0)
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #79 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 토큰 재발급 api 구현


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
<img width="980" height="500" alt="image" src="https://github.com/user-attachments/assets/4605ee3c-3b2b-4493-bef9-0e34d76864a3" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 리프레시 토큰 기반 토큰 재발급 API 추가: 쿠키의 리프레시 토큰으로 새 액세스 토큰 발급 및 새 리프레시 토큰을 쿠키에 저장
  * 리프레시 쿠키 명시적 삭제 기능 추가(로그아웃·강제 삭제)

* **개선사항**
  * 리프레시 토큰 회전 도입으로 동시성 안전성 향상
  * 토큰 유형 검사·검증 강화
  * 인증 오류 코드·메시지 세분화로 문제 진단 용이성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->