### PR TITLE
[Feat] 최근 검색어 조회 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/record/controller/RecordController.java
+++ b/src/main/java/com/umc/finly/domain/record/controller/RecordController.java
@@ -1,6 +1,15 @@
 package com.umc.finly.domain.record.controller;
 
-import com.umc.finly.domain.record.dto.*;
+import com.umc.finly.domain.record.dto.DailyReportRes;
+import com.umc.finly.domain.record.dto.RecentSearchRes;
+import com.umc.finly.domain.record.dto.RecordCreateReq;
+import com.umc.finly.domain.record.dto.RecordCreateRes;
+import com.umc.finly.domain.record.dto.RecordDetailRes;
+import com.umc.finly.domain.record.dto.RecordFeedbackRes;
+import com.umc.finly.domain.record.dto.RecordSearchRes;
+import com.umc.finly.domain.record.dto.RecordUpdateReq;
+import com.umc.finly.domain.record.dto.RecordUpdateRes;
+import com.umc.finly.domain.record.dto.TodayRecordRes;
 import com.umc.finly.domain.record.enums.EmotionCode;
 import com.umc.finly.domain.record.service.RecordFeedbackService;
 import com.umc.finly.domain.record.service.RecordService;
@@ -48,6 +57,14 @@ public class RecordController {
             @RequestParam(required = false) EmotionCode emotionCode
     ) {
         RecordSearchRes result = recordService.searchRecords(principal.getMemberId(), keyword, emotionCode);
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    @GetMapping("/search/recent")
+    public ApiResponse<RecentSearchRes> getRecentSearchKeywords(
+            @AuthenticationPrincipal AuthPrincipal principal
+    ) {
+        RecentSearchRes result = recordService.getRecentSearchKeywords(principal.getMemberId());
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }
 

--- a/src/main/java/com/umc/finly/domain/record/dto/RecentSearchRes.java
+++ b/src/main/java/com/umc/finly/domain/record/dto/RecentSearchRes.java
@@ -1,0 +1,19 @@
+package com.umc.finly.domain.record.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class RecentSearchRes {
+
+    private List<String> recentKeywords;
+
+    public static RecentSearchRes from(List<String> keywords) {
+        return RecentSearchRes.builder()
+                .recentKeywords(keywords)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/record/entity/SearchHistory.java
+++ b/src/main/java/com/umc/finly/domain/record/entity/SearchHistory.java
@@ -1,0 +1,28 @@
+package com.umc.finly.domain.record.entity;
+
+import com.umc.finly.global.entity.CreatedUpdatedDeletedBaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "search_history", indexes = {
+        @Index(name = "idx_search_history_member_keyword", columnList = "member_id, keyword"),
+        @Index(name = "idx_search_history_member_created", columnList = "member_id, created_at DESC")
+})
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class SearchHistory extends CreatedUpdatedDeletedBaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "keyword", nullable = false, length = 100)
+    private String keyword;
+}

--- a/src/main/java/com/umc/finly/domain/record/entity/SearchHistory.java
+++ b/src/main/java/com/umc/finly/domain/record/entity/SearchHistory.java
@@ -5,10 +5,17 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
-@Table(name = "search_history", indexes = {
-        @Index(name = "idx_search_history_member_keyword", columnList = "member_id, keyword"),
-        @Index(name = "idx_search_history_member_updated", columnList = "member_id, updated_at DESC")
-})
+@Table(name = "search_history",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_search_history_member_keyword",
+                        columnNames = {"member_id", "keyword"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_search_history_member_updated", columnList = "member_id, updated_at DESC")
+        }
+)
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/umc/finly/domain/record/entity/SearchHistory.java
+++ b/src/main/java/com/umc/finly/domain/record/entity/SearchHistory.java
@@ -3,8 +3,10 @@ package com.umc.finly.domain.record.entity;
 import com.umc.finly.global.entity.CreatedUpdatedDeletedBaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
+@SQLRestriction("deleted_at IS NULL")
 @Table(name = "search_history",
         uniqueConstraints = {
                 @UniqueConstraint(

--- a/src/main/java/com/umc/finly/domain/record/entity/SearchHistory.java
+++ b/src/main/java/com/umc/finly/domain/record/entity/SearchHistory.java
@@ -7,7 +7,7 @@ import lombok.*;
 @Entity
 @Table(name = "search_history", indexes = {
         @Index(name = "idx_search_history_member_keyword", columnList = "member_id, keyword"),
-        @Index(name = "idx_search_history_member_created", columnList = "member_id, created_at DESC")
+        @Index(name = "idx_search_history_member_updated", columnList = "member_id, updated_at DESC")
 })
 @Getter
 @Setter

--- a/src/main/java/com/umc/finly/domain/record/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/umc/finly/domain/record/repository/SearchHistoryRepository.java
@@ -1,6 +1,7 @@
 package com.umc.finly.domain.record.repository;
 
 import com.umc.finly.domain.record.entity.SearchHistory;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -16,13 +17,12 @@ public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Lo
     Optional<SearchHistory> findByMemberIdAndKeyword(Long memberId, String keyword);
 
     /**
-     * 해당 회원의 최근 검색 키워드 조회 (최신순, 중복 제거, 상위 N개)
+     * 해당 회원의 최근 검색 키워드 조회 (최신순, 상위 N개)
      */
     @Query("""
             SELECT sh.keyword FROM SearchHistory sh
             WHERE sh.memberId = :memberId
-            ORDER BY sh.createdAt DESC
-            LIMIT :limit
+            ORDER BY sh.updatedAt DESC
             """)
-    List<String> findRecentKeywordsByMemberId(@Param("memberId") Long memberId, @Param("limit") int limit);
+    List<String> findRecentKeywordsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/umc/finly/domain/record/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/umc/finly/domain/record/repository/SearchHistoryRepository.java
@@ -31,6 +31,6 @@ public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Lo
      * updatedAt 명시적 갱신 (touch)
      */
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE SearchHistory sh SET sh.updatedAt = CURRENT_TIMESTAMP WHERE sh.id = :id")
+    @Query("UPDATE SearchHistory sh SET sh.updatedAt = CURRENT_TIMESTAMP WHERE sh.id = :id AND sh.deletedAt IS NULL")
     int touchUpdatedAt(@Param("id") Long id);
 }

--- a/src/main/java/com/umc/finly/domain/record/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/umc/finly/domain/record/repository/SearchHistoryRepository.java
@@ -3,6 +3,7 @@ package com.umc.finly.domain.record.repository;
 import com.umc.finly.domain.record.entity.SearchHistory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -25,4 +26,11 @@ public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Lo
             ORDER BY sh.updatedAt DESC
             """)
     List<String> findRecentKeywordsByMemberId(@Param("memberId") Long memberId, Pageable pageable);
+
+    /**
+     * updatedAt 명시적 갱신 (touch)
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE SearchHistory sh SET sh.updatedAt = CURRENT_TIMESTAMP WHERE sh.id = :id")
+    int touchUpdatedAt(@Param("id") Long id);
 }

--- a/src/main/java/com/umc/finly/domain/record/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/umc/finly/domain/record/repository/SearchHistoryRepository.java
@@ -1,0 +1,28 @@
+package com.umc.finly.domain.record.repository;
+
+import com.umc.finly.domain.record.entity.SearchHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Long> {
+
+    /**
+     * 해당 회원의 동일 키워드 검색 기록 조회
+     */
+    Optional<SearchHistory> findByMemberIdAndKeyword(Long memberId, String keyword);
+
+    /**
+     * 해당 회원의 최근 검색 키워드 조회 (최신순, 중복 제거, 상위 N개)
+     */
+    @Query("""
+            SELECT sh.keyword FROM SearchHistory sh
+            WHERE sh.memberId = :memberId
+            ORDER BY sh.createdAt DESC
+            LIMIT :limit
+            """)
+    List<String> findRecentKeywordsByMemberId(@Param("memberId") Long memberId, @Param("limit") int limit);
+}

--- a/src/main/java/com/umc/finly/domain/record/service/RecordService.java
+++ b/src/main/java/com/umc/finly/domain/record/service/RecordService.java
@@ -1,6 +1,7 @@
 package com.umc.finly.domain.record.service;
 
 import com.umc.finly.domain.record.dto.DailyReportRes;
+import com.umc.finly.domain.record.dto.RecentSearchRes;
 import com.umc.finly.domain.record.dto.RecordCreateReq;
 import com.umc.finly.domain.record.dto.RecordCreateRes;
 import com.umc.finly.domain.record.dto.RecordDetailRes;
@@ -19,4 +20,5 @@ public interface RecordService {
     DailyReportRes getDailyReport(Long memberId, Long recordId);
     TodayRecordRes getTodayRecords(Long memberId, LocalDate date);
     RecordSearchRes searchRecords(Long memberId, String keyword, EmotionCode emotionCode);
+    RecentSearchRes getRecentSearchKeywords(Long memberId);
 }

--- a/src/main/java/com/umc/finly/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/record/service/RecordServiceImpl.java
@@ -3,6 +3,7 @@ package com.umc.finly.domain.record.service;
 import com.umc.finly.domain.market.stock.entity.Stock;
 import com.umc.finly.domain.market.stock.repository.StockRepository;
 import com.umc.finly.domain.record.dto.DailyReportRes;
+import com.umc.finly.domain.record.dto.RecentSearchRes;
 import com.umc.finly.domain.record.dto.RecordCreateReq;
 import com.umc.finly.domain.record.dto.RecordCreateRes;
 import com.umc.finly.domain.record.dto.RecordDetailRes;
@@ -13,10 +14,12 @@ import com.umc.finly.domain.record.dto.TodayRecordRes;
 import com.umc.finly.domain.record.infra.OpenAiFeedbackClient;
 import com.umc.finly.domain.record.entity.RecordEntry;
 import com.umc.finly.domain.record.entity.RecordFeedback;
+import com.umc.finly.domain.record.entity.SearchHistory;
 import com.umc.finly.domain.record.enums.EmotionCode;
 import com.umc.finly.domain.record.enums.Session;
 import com.umc.finly.domain.record.enums.TradeAction;
 import com.umc.finly.domain.record.repository.RecordEntryRepository;
+import com.umc.finly.domain.record.repository.SearchHistoryRepository;
 import com.umc.finly.global.apiPayload.exception.CustomException;
 import com.umc.finly.domain.record.exception.RecordErrorCode;
 import com.umc.finly.domain.market.exception.code.MarketErrorCode;
@@ -44,6 +47,9 @@ public class RecordServiceImpl implements RecordService {
     private final RecordFeedbackService feedbackService;
     private final StockRepository stockRepository;
     private final OpenAiFeedbackClient openAiFeedbackClient;
+    private final SearchHistoryRepository searchHistoryRepository;
+
+    private static final int RECENT_SEARCH_LIMIT = 3;
 
     @Override
     @Transactional
@@ -253,8 +259,14 @@ public class RecordServiceImpl implements RecordService {
     }
 
     @Override
+    @Transactional
     public RecordSearchRes searchRecords(Long memberId, String keyword, EmotionCode emotionCode) {
-        // 1. keyword가 있으면 종목명 매칭 stockId 목록 조회
+        // 1. keyword가 있으면 검색 기록 저장 (중복 시 시간 업데이트)
+        if (keyword != null && !keyword.isBlank()) {
+            saveSearchHistory(memberId, keyword.trim());
+        }
+
+        // 2. keyword가 있으면 종목명 매칭 stockId 목록 조회
         List<Long> stockIds = null;
         if (keyword != null && !keyword.isBlank()) {
             stockIds = stockRepository.findByNameContaining(keyword).stream()
@@ -265,11 +277,11 @@ public class RecordServiceImpl implements RecordService {
             }
         }
 
-        // 2. RecordEntry 검색
+        // 3. RecordEntry 검색
         List<RecordEntry> entries = recordEntryRepository.searchRecords(
                 memberId, emotionCode, keyword, stockIds);
 
-        // 3. 결과의 stockId 일괄 조회 → Stock Map 생성
+        // 4. 결과의 stockId 일괄 조회 → Stock Map 생성
         List<Long> resultStockIds = entries.stream()
                 .map(RecordEntry::getStockId)
                 .distinct()
@@ -277,7 +289,7 @@ public class RecordServiceImpl implements RecordService {
         Map<Long, Stock> stockMap = stockRepository.findAllById(resultStockIds).stream()
                 .collect(Collectors.toMap(Stock::getId, Function.identity()));
 
-        // 4. 응답 DTO 생성
+        // 5. 응답 DTO 생성
         List<RecordSearchRes.SearchEntry> searchEntries = entries.stream()
                 .map(entry -> {
                     Stock stock = stockMap.get(entry.getStockId());
@@ -290,5 +302,39 @@ public class RecordServiceImpl implements RecordService {
                 .records(searchEntries)
                 .totalCount(searchEntries.size())
                 .build();
+    }
+
+    @Override
+    public RecentSearchRes getRecentSearchKeywords(Long memberId) {
+        List<String> recentKeywords = searchHistoryRepository
+                .findRecentKeywordsByMemberId(memberId, RECENT_SEARCH_LIMIT);
+        return RecentSearchRes.from(recentKeywords);
+    }
+
+    /**
+     * 검색 키워드 저장 (중복 키워드는 시간 업데이트)
+     */
+    private void saveSearchHistory(Long memberId, String keyword) {
+        searchHistoryRepository.findByMemberIdAndKeyword(memberId, keyword)
+                .ifPresentOrElse(
+                        // 기존 기록이 있으면 삭제 후 새로 저장 (최신 시간으로 갱신)
+                        existing -> {
+                            searchHistoryRepository.delete(existing);
+                            searchHistoryRepository.flush();
+                            SearchHistory newHistory = SearchHistory.builder()
+                                    .memberId(memberId)
+                                    .keyword(keyword)
+                                    .build();
+                            searchHistoryRepository.save(newHistory);
+                        },
+                        // 기존 기록이 없으면 새로 저장
+                        () -> {
+                            SearchHistory history = SearchHistory.builder()
+                                    .memberId(memberId)
+                                    .keyword(keyword)
+                                    .build();
+                            searchHistoryRepository.save(history);
+                        }
+                );
     }
 }

--- a/src/main/java/com/umc/finly/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/record/service/RecordServiceImpl.java
@@ -25,6 +25,7 @@ import com.umc.finly.domain.record.exception.RecordErrorCode;
 import com.umc.finly.domain.market.exception.code.MarketErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -307,26 +308,18 @@ public class RecordServiceImpl implements RecordService {
     @Override
     public RecentSearchRes getRecentSearchKeywords(Long memberId) {
         List<String> recentKeywords = searchHistoryRepository
-                .findRecentKeywordsByMemberId(memberId, RECENT_SEARCH_LIMIT);
+                .findRecentKeywordsByMemberId(memberId, PageRequest.of(0, RECENT_SEARCH_LIMIT));
         return RecentSearchRes.from(recentKeywords);
     }
 
     /**
-     * 검색 키워드 저장 (중복 키워드는 시간 업데이트)
+     * 검색 키워드 저장 (중복 키워드는 updatedAt 갱신)
      */
     private void saveSearchHistory(Long memberId, String keyword) {
         searchHistoryRepository.findByMemberIdAndKeyword(memberId, keyword)
                 .ifPresentOrElse(
-                        // 기존 기록이 있으면 삭제 후 새로 저장 (최신 시간으로 갱신)
-                        existing -> {
-                            searchHistoryRepository.delete(existing);
-                            searchHistoryRepository.flush();
-                            SearchHistory newHistory = SearchHistory.builder()
-                                    .memberId(memberId)
-                                    .keyword(keyword)
-                                    .build();
-                            searchHistoryRepository.save(newHistory);
-                        },
+                        // 기존 기록이 있으면 updatedAt 갱신 (touch)
+                        searchHistoryRepository::save,
                         // 기존 기록이 없으면 새로 저장
                         () -> {
                             SearchHistory history = SearchHistory.builder()

--- a/src/main/java/com/umc/finly/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/record/service/RecordServiceImpl.java
@@ -328,11 +328,17 @@ public class RecordServiceImpl implements RecordService {
                         existing -> searchHistoryRepository.touchUpdatedAt(existing.getId()),
                         // 기존 기록이 없으면 새로 저장
                         () -> {
-                            SearchHistory history = SearchHistory.builder()
-                                    .memberId(memberId)
-                                    .keyword(keyword)
-                                    .build();
-                            searchHistoryRepository.save(history);
+                            try {
+                                SearchHistory history = SearchHistory.builder()
+                                        .memberId(memberId)
+                                        .keyword(keyword)
+                                        .build();
+                                searchHistoryRepository.save(history);
+                            } catch (DataIntegrityViolationException e) {
+                                // 동시 요청으로 이미 저장된 경우 updatedAt 갱신
+                                searchHistoryRepository.findByMemberIdAndKeyword(memberId, keyword)
+                                .ifPresent(existing -> searchHistoryRepository.touchUpdatedAt(existing.getId()));
+                            }
                         }
                 );
     }

--- a/src/main/java/com/umc/finly/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/record/service/RecordServiceImpl.java
@@ -319,7 +319,7 @@ public class RecordServiceImpl implements RecordService {
         searchHistoryRepository.findByMemberIdAndKeyword(memberId, keyword)
                 .ifPresentOrElse(
                         // 기존 기록이 있으면 updatedAt 갱신 (touch)
-                        searchHistoryRepository::save,
+                        existing -> searchHistoryRepository.touchUpdatedAt(existing.getId()),
                         // 기존 기록이 없으면 새로 저장
                         () -> {
                             SearchHistory history = SearchHistory.builder()

--- a/src/main/java/com/umc/finly/domain/record/service/RecordServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/record/service/RecordServiceImpl.java
@@ -262,15 +262,21 @@ public class RecordServiceImpl implements RecordService {
     @Override
     @Transactional
     public RecordSearchRes searchRecords(Long memberId, String keyword, EmotionCode emotionCode) {
-        // 1. keyword가 있으면 검색 기록 저장 (중복 시 시간 업데이트)
-        if (keyword != null && !keyword.isBlank()) {
-            saveSearchHistory(memberId, keyword.trim());
+        // 1. 키워드 정규화
+        String normalizedKeyword = (keyword == null) ? null : keyword.strip();
+        if (normalizedKeyword != null && normalizedKeyword.isBlank()) {
+            normalizedKeyword = null;
         }
 
-        // 2. keyword가 있으면 종목명 매칭 stockId 목록 조회
+        // 2. keyword가 있으면 검색 기록 저장 (중복 시 시간 업데이트)
+        if (normalizedKeyword != null) {
+            saveSearchHistory(memberId, normalizedKeyword);
+        }
+
+        // 3. keyword가 있으면 종목명 매칭 stockId 목록 조회
         List<Long> stockIds = null;
-        if (keyword != null && !keyword.isBlank()) {
-            stockIds = stockRepository.findByNameContaining(keyword).stream()
+        if (normalizedKeyword != null) {
+            stockIds = stockRepository.findByNameContaining(normalizedKeyword).stream()
                     .map(Stock::getId)
                     .toList();
             if (stockIds.isEmpty()) {
@@ -278,11 +284,11 @@ public class RecordServiceImpl implements RecordService {
             }
         }
 
-        // 3. RecordEntry 검색
+        // 4. RecordEntry 검색
         List<RecordEntry> entries = recordEntryRepository.searchRecords(
-                memberId, emotionCode, keyword, stockIds);
+                memberId, emotionCode, normalizedKeyword, stockIds);
 
-        // 4. 결과의 stockId 일괄 조회 → Stock Map 생성
+        // 5. 결과의 stockId 일괄 조회 → Stock Map 생성
         List<Long> resultStockIds = entries.stream()
                 .map(RecordEntry::getStockId)
                 .distinct()
@@ -290,7 +296,7 @@ public class RecordServiceImpl implements RecordService {
         Map<Long, Stock> stockMap = stockRepository.findAllById(resultStockIds).stream()
                 .collect(Collectors.toMap(Stock::getId, Function.identity()));
 
-        // 5. 응답 DTO 생성
+        // 6. 응답 DTO 생성
         List<RecordSearchRes.SearchEntry> searchEntries = entries.stream()
                 .map(entry -> {
                     Stock stock = stockMap.get(entry.getStockId());


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #81 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 최근 기록 검색

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

[최근 기록 검색 API (GET /api/records/search/recent)](https://www.notion.so/_-2f2b7acc900f80c5b8e4df72325693d2#2fcb7acc900f80608cf2f929ae2124c5)

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 최근 검색 키워드 조회 API 추가: 사용자가 최근 검색한 키워드 목록을 확인할 수 있습니다.
  * 검색 이력 자동 저장 및 갱신: 키워드 검색 시 자동 저장되고, 동일 키워드 재검색 시 최신 순으로 갱신됩니다.
  * 최근 키워드 목록은 최신 순으로 제한된 개수만 반환되어 가독성과 재검색 편의성을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->