### PR TITLE
[Feat] 로그아웃 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/finly/domain/auth/controller/AuthController.java
@@ -138,4 +138,32 @@ public class AuthController {
                 SuccessCode.OK
         );
     }
+
+    /**
+     * 로그아웃
+     */
+    @Operation(
+            summary = "로그아웃",
+            description = """
+                Access Token 기반으로 로그아웃 처리합니다.
+                
+                - Authorization 헤더의 Access Token으로 사용자를 인증합니다.
+                - 서버(DB)에 저장된 해당 사용자의 Refresh Token 및 만료 시각을 제거합니다.
+                - 클라이언트에 저장된 Refresh Token 쿠키(refreshToken)를 Max-Age=0으로 설정하여 삭제합니다.
+                - 성공 시 빈 result({})를 반환합니다.
+                
+                ✅ 요청 헤더
+                - Authorization: Bearer {accessToken}
+                
+                ✅ 동작 방식
+                - Refresh Token은 HttpOnly Cookie로 관리되므로, 서버는 쿠키를 삭제(Set-Cookie)로 무효화합니다.
+                - (참고) Access Token은 서버 저장소가 없으므로 만료 전까지는 클라이언트에서 폐기하는 것이 일반적입니다.
+                """
+    )
+    @PostMapping("/logout")
+    public ApiResponse<Object> logout(HttpServletResponse response){
+        authService.logout(response);
+
+        return ApiResponse.onSuccess(new Object(), SuccessCode.OK);
+    }
 }

--- a/src/main/java/com/umc/finly/domain/auth/service/AuthService.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import com.umc.finly.domain.auth.dto.req.AuthLoginReqDTO;
 import com.umc.finly.domain.auth.dto.req.AuthSignUpReqDTO;
 import com.umc.finly.domain.auth.dto.res.AuthLoginResDTO;
 import com.umc.finly.domain.auth.dto.res.AuthSignUpResDTO;
+import jakarta.servlet.http.HttpServletResponse;
 
 public interface AuthService {
     boolean isEmailAvailable(String email);
@@ -13,6 +14,8 @@ public interface AuthService {
     LoginTokens login(AuthLoginReqDTO request);
 
     ReissueTokens reissue(String refreshToken);
+
+    void logout(HttpServletResponse response);
 
     record LoginTokens(
             AuthLoginResDTO body,

--- a/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
@@ -244,8 +244,7 @@ public class AuthServiceImpl implements AuthService {
                 .orElseThrow(()-> new CustomException(AuthErrorCode.INVALID_ACCESS_TOKEN));
 
         member.clearRefreshToken();
-        memberRepository.save(member);
-
+        cookieUtil.clearRefreshTokenCookie(response);
     }
 
     // -----------------------------------------------------------

--- a/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
@@ -19,8 +19,11 @@ import com.umc.finly.domain.member.repository.MemberTermRepository;
 import com.umc.finly.domain.member.service.PersonaScoringService;
 import com.umc.finly.global.apiPayload.exception.CustomException;
 import com.umc.finly.global.infra.jwt.JwtProvider;
+import com.umc.finly.global.util.CookieUtil;
+import com.umc.finly.global.util.SecurityUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -56,6 +59,7 @@ public class AuthServiceImpl implements AuthService {
     // 필수 약관 정의
     private static final EnumSet<TermType> REQUIRED_TERMS =
             EnumSet.of(TermType.TERMS_AGREED, TermType.PRIVACY_AGREED);
+    private final CookieUtil cookieUtil;
 
     /** 이메일 중복 확인 **/
     @Override
@@ -231,6 +235,18 @@ public class AuthServiceImpl implements AuthService {
         return new ReissueTokens(newAccessToken, newRefreshToken, refreshMaxAgeSeconds);
     }
 
+    /** 로그아웃 **/
+    @Override
+    public void logout(HttpServletResponse response){
+        Long memberId = SecurityUtil.getCurrentMemberId();
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()-> new CustomException(AuthErrorCode.INVALID_ACCESS_TOKEN));
+
+        member.clearRefreshToken();
+        memberRepository.save(member);
+
+    }
 
     // -----------------------------------------------------------
     private boolean isValidPassword(String raw) {

--- a/src/main/java/com/umc/finly/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/finly/global/config/security/SecurityConfig.java
@@ -85,6 +85,7 @@ public class SecurityConfig {
                 /** [URL 접근 권한 설정] **/
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/auth/logout").authenticated()
 
                         // PUBLIC
                         .requestMatchers("/auth/**", "/api/persona-test/questions").permitAll()

--- a/src/main/java/com/umc/finly/global/util/SecurityUtil.java
+++ b/src/main/java/com/umc/finly/global/util/SecurityUtil.java
@@ -2,6 +2,8 @@ package com.umc.finly.global.util;
 
 import com.umc.finly.global.apiPayload.exception.CustomException;
 import com.umc.finly.global.apiPayload.response.ErrorCode;
+import com.umc.finly.global.config.security.AuthPrincipal;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -10,15 +12,33 @@ public class SecurityUtil {
     public static Long getCurrentMemberId() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 
-        if (auth == null || !auth.isAuthenticated() || auth.getPrincipal() == null) {
+        // 인증 객체 자체가 없거나 인증 안 된 경우
+        if (auth == null || !auth.isAuthenticated()) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // 익명 사용자 방어 (anonymousUser도 isAuthenticated=true일 수 있음)
+        if (auth instanceof AnonymousAuthenticationToken) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
         Object principal = auth.getPrincipal();
-        if (!(principal instanceof Long)) {
+        if (principal == null) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
-        return (Long) principal;
+        // AuthPrincipal을 principal로 세팅하는 경우
+        if (principal instanceof AuthPrincipal ap) {
+            // AuthPrincipal이 record면 ap.memberId()
+            // class + getter면 ap.getMemberId()
+            return ap.getMemberId();
+        }
+
+        // Long으로 세팅하는 경우도 지원
+        if (principal instanceof Long memberId) {
+            return memberId;
+        }
+
+        throw new CustomException(ErrorCode.UNAUTHORIZED);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #89 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 로그아웃 api 구현
- SecurityUtil 확장


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

### 로그아웃 실행
<img width="778" height="568" alt="image" src="https://github.com/user-attachments/assets/74a38539-fe80-4717-bfdd-345c7da5e06c" />

### 리프레시토큰이 없어서 리이슈 안되는 모습
<img width="1010" height="580" alt="image" src="https://github.com/user-attachments/assets/99908908-69a6-4e09-befd-d260771562bb" />

### DB 
<img width="3042" height="352" alt="image" src="https://github.com/user-attachments/assets/c182896c-e228-4803-9d28-e8cca1b44d05" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그아웃 기능이 추가되었습니다. 사용자는 이제 명시적으로 로그아웃할 수 있으며, 서버에 저장된 인증 토큰이 안전하게 삭제됩니다.

* **보안 개선**
  * 인증 검증 로직이 강화되어 더욱 안전한 사용자 세션 관리가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->