### PR TITLE
[Feat] 최근 나의 기록 조회 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/home/controller/HomeRecordController.java
+++ b/src/main/java/com/umc/finly/domain/home/controller/HomeRecordController.java
@@ -5,6 +5,8 @@ import com.umc.finly.domain.home.service.HomeRecordService;
 import com.umc.finly.global.apiPayload.response.ApiResponse;
 import com.umc.finly.global.apiPayload.response.SuccessCode;
 import com.umc.finly.global.config.security.AuthPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +19,42 @@ import org.springframework.web.bind.annotation.RestController;
 public class HomeRecordController {
 
     private final HomeRecordService homeRecordService;
+    @Operation(
+            summary = "최근 나의 기록 조회",
+            description = """
+        홈 화면에서 로그인한 사용자의 최근 기록 목록을 조회합니다.
+
+        조회 기준
+        - 검색 조건 없이 전체 기록을 기준으로 조회합니다.
+        - 오늘 기준 최근 3일 이내 기록만 필터링합니다.
+        - 기록은 최신순(recordedAt DESC)으로 정렬됩니다.
+        - 최대 5개의 기록만 반환됩니다.
+
+        처리 방식
+        - 기존 기록 검색 로직을 재사용하여 조회합니다.
+        - Home 도메인에서 기간 및 개수 정책을 적용합니다.
+        - 기록이 없는 경우 빈 배열을 반환합니다.
+
+        유의사항
+        - 인증되지 않은 사용자는 조회할 수 없습니다.
+        - 기록 날짜(recordDate)는 일 단위 기준입니다.
+        - 최신순 정렬 기준은 recordedAt(생성 시각)입니다.
+        """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "최근 나의 기록 조회 성공"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 실패"
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "500",
+                    description = "서버 내부 오류"
+            )
+    })
 
     @GetMapping("/records")
     public ApiResponse<HomeRecordsRes> getRecentMyRecords(

--- a/src/main/java/com/umc/finly/domain/home/controller/HomeRecordController.java
+++ b/src/main/java/com/umc/finly/domain/home/controller/HomeRecordController.java
@@ -1,0 +1,29 @@
+package com.umc.finly.domain.home.controller;
+
+import com.umc.finly.domain.home.dto.HomeRecordsRes;
+import com.umc.finly.domain.home.service.HomeRecordService;
+import com.umc.finly.global.apiPayload.response.ApiResponse;
+import com.umc.finly.global.apiPayload.response.SuccessCode;
+import com.umc.finly.global.config.security.AuthPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/home")
+public class HomeRecordController {
+
+    private final HomeRecordService homeRecordService;
+
+    @GetMapping("/records")
+    public ApiResponse<HomeRecordsRes> getRecentMyRecords(
+            @AuthenticationPrincipal AuthPrincipal principal
+    ) {
+        HomeRecordsRes result = homeRecordService.getRecentMyRecords(principal.getMemberId());
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+}

--- a/src/main/java/com/umc/finly/domain/home/dto/HomeRecordsRes.java
+++ b/src/main/java/com/umc/finly/domain/home/dto/HomeRecordsRes.java
@@ -1,0 +1,41 @@
+package com.umc.finly.domain.home.dto;
+import com.umc.finly.domain.record.enums.EmotionCode;
+import com.umc.finly.domain.record.enums.Session;
+import com.umc.finly.domain.record.enums.TradeAction;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class HomeRecordsRes {
+
+    private List<Record> records;
+
+    @Getter
+    @Builder
+    public static class Record {
+
+        private Long recordId;
+        private LocalDate recordDate;
+        private LocalDateTime recordedAt;
+        private Session session;
+        private TradeAction tradeAction;
+        private String symbol;
+        private BigDecimal unitPrice;
+        private BigDecimal quantity;
+        private EmotionCode emotionCode;
+        private Integer emotionIntensity;
+        private String memo;
+    }
+
+    public static HomeRecordsRes from(List<Record> records) {
+        return HomeRecordsRes.builder()
+                .records(records)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/home/exception/code/HomeErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/home/exception/code/HomeErrorCode.java
@@ -1,0 +1,34 @@
+package com.umc.finly.domain.home.exception.code;
+
+import com.umc.finly.global.apiPayload.response.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum HomeErrorCode implements BaseCode {
+
+    // 홈 - 최근 나의 기록
+    HOME_RECENT_RECORDS_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "HOME_RECENT_RECORDS_NOT_FOUND",
+            "최근 나의 기록이 존재하지 않습니다."
+    ),
+
+    HOME_RECENT_RECORDS_ACCESS_DENIED(
+            HttpStatus.FORBIDDEN,
+            "HOME_RECENT_RECORDS_ACCESS_DENIED",
+            "최근 기록 조회 권한이 없습니다."
+    ),
+
+    HOME_RECENT_RECORDS_INTERNAL_ERROR(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "HOME_RECENT_RECORDS_INTERNAL_ERROR",
+            "최근 나의 기록 조회 중 서버 오류가 발생했습니다."
+    );
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/finly/domain/home/service/HomeRecordService.java
+++ b/src/main/java/com/umc/finly/domain/home/service/HomeRecordService.java
@@ -1,0 +1,8 @@
+package com.umc.finly.domain.home.service;
+
+import com.umc.finly.domain.home.dto.HomeRecordsRes;
+
+public interface HomeRecordService {
+
+    HomeRecordsRes getRecentMyRecords(Long memberId);
+}

--- a/src/main/java/com/umc/finly/domain/home/service/HomeRecordServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/home/service/HomeRecordServiceImpl.java
@@ -1,0 +1,58 @@
+package com.umc.finly.domain.home.service;
+
+import com.umc.finly.domain.home.dto.HomeRecordsRes;
+import com.umc.finly.domain.record.dto.RecordSearchRes;
+import com.umc.finly.domain.record.service.RecordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class HomeRecordServiceImpl implements HomeRecordService {
+
+    private final RecordService recordService;
+
+    @Override
+    public HomeRecordsRes getRecentMyRecords(Long memberId) {
+
+        // 기존 기록 검색 API 로직 재사용
+        RecordSearchRes searchRes =
+                recordService.searchRecords(memberId, null, null);
+
+        // 2️Home 정책 적용
+        LocalDate threeDaysAgo = LocalDate.now().minusDays(3);
+
+        List<HomeRecordsRes.Record> records =
+                searchRes.getRecords().stream()
+                        // 최근 3일
+                        .filter(r -> !r.getRecordDate().isBefore(threeDaysAgo))
+                        // 최신순
+                        .sorted(Comparator.comparing(
+                                RecordSearchRes.SearchEntry::getRecordedAt
+                        ).reversed())
+                        // 상위 5개
+                        .limit(5)
+                        // DTO 변환
+                        .map(r -> HomeRecordsRes.Record.builder()
+                                .recordId(r.getRecordId())
+                                .recordDate(r.getRecordDate())
+                                .recordedAt(r.getRecordedAt())
+                                .session(r.getSession())
+                                .tradeAction(r.getTradeAction())
+                                .symbol(r.getSymbol())
+                                .unitPrice(r.getUnitPrice())
+                                .quantity(r.getQuantity())
+                                .emotionCode(r.getEmotionCode())
+                                .emotionIntensity(r.getEmotionIntensity())
+                                .memo(r.getMemo())
+                                .build()
+                        )
+                        .toList();
+
+        return HomeRecordsRes.from(records);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> #94 

closes #94 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- HOME 도메인에 최근 나의 기록 조회 API(/api/home/records) 구현했습니다
- 로그인한 사용자의 기록을 최신순 기준으로 조회됩니다. 
- 최신 기록 기준 필터링 로직 적용했습니다 


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
<img width="1068" height="586" alt="image" src="https://github.com/user-attachments/assets/608cdeee-3de6-4063-a84a-f902d045b706" />

<img width="1008" height="516" alt="image" src="https://github.com/user-attachments/assets/4d4fbe52-2587-45ba-adfd-14868da48313" />

/api/home/records 호출 시 로그인 사용자 기준 최신 기록 정상 조회

기록이 없는 경우 빈 리스트 반환 확인


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 최근 거래 기록을 조회할 수 있는 새로운 API 엔드포인트 추가
  * 인증된 사용자가 최근 3일간의 거래 기록(최대 5개)을 빠르게 확인 가능
  * 거래 날짜, 가격, 수량, 감정 정보 등 상세 기록 조회 기능 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->