### PR TITLE
[Feat] 위클리무드 조회 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/home/controller/HomeWeeklyMoodController.java
+++ b/src/main/java/com/umc/finly/domain/home/controller/HomeWeeklyMoodController.java
@@ -1,0 +1,37 @@
+package com.umc.finly.domain.home.controller;
+
+import com.umc.finly.domain.home.dto.HomeWeeklyMoodRes;
+import com.umc.finly.domain.home.service.HomeWeeklyMoodService;
+import com.umc.finly.global.apiPayload.response.ApiResponse;
+import com.umc.finly.global.apiPayload.response.SuccessCode;
+import com.umc.finly.global.config.security.AuthPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/home")
+public class HomeWeeklyMoodController {
+
+    private final HomeWeeklyMoodService homeWeeklyMoodService;
+
+    @Operation(
+            summary = "위클리 무드 조회",
+            description = """
+            로그인한 사용자의 이번 주(월~일) 기록을 기준으로 요일별 감정 요약 정보를 반환합니다.
+            
+            - 기록이 없는 요일은 hasRecord=false로 표시됩니다
+            """
+    )
+    @GetMapping("/weekly")
+    public ApiResponse<HomeWeeklyMoodRes> getWeeklyMood(
+            @AuthenticationPrincipal AuthPrincipal principal
+    ) {
+        HomeWeeklyMoodRes result =
+                homeWeeklyMoodService.getWeeklyMood(principal.getMemberId());
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+}

--- a/src/main/java/com/umc/finly/domain/home/dto/HomeWeeklyMoodRes.java
+++ b/src/main/java/com/umc/finly/domain/home/dto/HomeWeeklyMoodRes.java
@@ -1,0 +1,22 @@
+package com.umc.finly.domain.home.dto;
+
+import com.umc.finly.domain.record.enums.EmotionCode;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class HomeWeeklyMoodRes {
+
+    private List<DayMood> days;
+
+    @Getter
+    @Builder
+    public static class DayMood {
+        private String dayOfWeek;      // 요일
+        private boolean hasRecord;     // 기록 존재 여부 없으면 null로 출력하기
+        private EmotionCode emotion;   // 대표 감정
+    }
+}

--- a/src/main/java/com/umc/finly/domain/home/exception/code/HomeErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/home/exception/code/HomeErrorCode.java
@@ -26,7 +26,14 @@ public enum HomeErrorCode implements BaseCode {
             HttpStatus.INTERNAL_SERVER_ERROR,
             "HOME_RECENT_RECORDS_INTERNAL_ERROR",
             "최근 나의 기록 조회 중 서버 오류가 발생했습니다."
+    ),
+
+    HOME_WEEKLY_MOOD_INTERNAL_ERROR(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "HOME_WEEKLY_MOOD_INTERNAL_ERROR",
+            "위클리 무드 조회 중 서버 오류가 발생했습니다."
     );
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/finly/domain/home/repository/HomeRecordRepository.java
+++ b/src/main/java/com/umc/finly/domain/home/repository/HomeRecordRepository.java
@@ -1,0 +1,16 @@
+package com.umc.finly.domain.home.repository;
+
+import com.umc.finly.domain.record.entity.RecordEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface HomeRecordRepository extends JpaRepository<RecordEntry, Long> {
+
+    List<RecordEntry> findByMemberIdAndRecordDateBetween(
+            Long memberId,
+            LocalDate start,
+            LocalDate end
+    );
+}

--- a/src/main/java/com/umc/finly/domain/home/repository/HomeRecordRepository.java
+++ b/src/main/java/com/umc/finly/domain/home/repository/HomeRecordRepository.java
@@ -5,10 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface HomeRecordRepository extends JpaRepository<RecordEntry, Long> {
 
-    List<RecordEntry> findByMemberIdAndRecordDateBetween(
+    Optional<List<RecordEntry>> findByMemberIdAndRecordDateBetween(
             Long memberId,
             LocalDate start,
             LocalDate end

--- a/src/main/java/com/umc/finly/domain/home/service/HomeWeeklyMoodService.java
+++ b/src/main/java/com/umc/finly/domain/home/service/HomeWeeklyMoodService.java
@@ -1,0 +1,8 @@
+package com.umc.finly.domain.home.service;
+
+import com.umc.finly.domain.home.dto.HomeWeeklyMoodRes;
+
+public interface HomeWeeklyMoodService {
+
+    HomeWeeklyMoodRes getWeeklyMood(Long memberId);
+}

--- a/src/main/java/com/umc/finly/domain/home/service/HomeWeeklyMoodServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/home/service/HomeWeeklyMoodServiceImpl.java
@@ -1,8 +1,10 @@
 package com.umc.finly.domain.home.service;
 
 import com.umc.finly.domain.home.dto.HomeWeeklyMoodRes;
+import com.umc.finly.domain.home.exception.code.HomeErrorCode;
 import com.umc.finly.domain.home.repository.HomeRecordRepository;
 import com.umc.finly.domain.record.entity.RecordEntry;
+import com.umc.finly.global.apiPayload.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,6 +22,7 @@ public class HomeWeeklyMoodServiceImpl implements HomeWeeklyMoodService {
     @Override
     public HomeWeeklyMoodRes getWeeklyMood(Long memberId) {
 
+
         LocalDate today = LocalDate.now();
         LocalDate monday = today.with(DayOfWeek.MONDAY);
         LocalDate sunday = today.with(DayOfWeek.SUNDAY);
@@ -27,8 +30,10 @@ public class HomeWeeklyMoodServiceImpl implements HomeWeeklyMoodService {
 
         List<RecordEntry> records =
                 homeRecordRepository.findByMemberIdAndRecordDateBetween(
-                        //  ️이번 주 동안 사용자가 작성한 모든 기록 조회 recordDate 기준
+                        //  //  ️이번 주 동안 사용자가 작성한 모든 기록 조회 recordDate 기준
                         memberId, monday, sunday
+                ).orElseThrow(() ->
+                        new CustomException(HomeErrorCode.HOME_WEEKLY_MOOD_INTERNAL_ERROR) // 에러 추가
                 );
 
         //기록을 요일(DayOfWeek) 기준으로 그룹핑
@@ -69,7 +74,6 @@ public class HomeWeeklyMoodServiceImpl implements HomeWeeklyMoodService {
                     .emotion(lastRecord.getEmotionCode())
                     .build());
         }
-
 
         return HomeWeeklyMoodRes.builder()
                 .days(days)

--- a/src/main/java/com/umc/finly/domain/home/service/HomeWeeklyMoodServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/home/service/HomeWeeklyMoodServiceImpl.java
@@ -64,7 +64,7 @@ public class HomeWeeklyMoodServiceImpl implements HomeWeeklyMoodService {
                             .orElseThrow();
 
             days.add(HomeWeeklyMoodRes.DayMood.builder()
-                    .dayOfWeek(day.name().substring(0, 3))
+                    .dayOfWeek(toKoreanDay(day))
                     .hasRecord(true)
                     .emotion(lastRecord.getEmotionCode())
                     .build());
@@ -75,4 +75,20 @@ public class HomeWeeklyMoodServiceImpl implements HomeWeeklyMoodService {
                 .days(days)
                 .build();
     }
+
+
+    // 한글 요일 변환 유틸 메서드
+    private String toKoreanDay(DayOfWeek day) {
+        return switch (day) {
+            case MONDAY -> "월";
+            case TUESDAY -> "화";
+            case WEDNESDAY -> "수";
+            case THURSDAY -> "목";
+            case FRIDAY -> "금";
+            case SATURDAY -> "토";
+            case SUNDAY -> "일";
+        };
+    }
+
+
 }

--- a/src/main/java/com/umc/finly/domain/home/service/HomeWeeklyMoodServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/home/service/HomeWeeklyMoodServiceImpl.java
@@ -1,0 +1,78 @@
+package com.umc.finly.domain.home.service;
+
+import com.umc.finly.domain.home.dto.HomeWeeklyMoodRes;
+import com.umc.finly.domain.home.repository.HomeRecordRepository;
+import com.umc.finly.domain.record.entity.RecordEntry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class HomeWeeklyMoodServiceImpl implements HomeWeeklyMoodService {
+
+    private final HomeRecordRepository homeRecordRepository;
+
+    @Override
+    public HomeWeeklyMoodRes getWeeklyMood(Long memberId) {
+
+        LocalDate today = LocalDate.now();
+        LocalDate monday = today.with(DayOfWeek.MONDAY);
+        LocalDate sunday = today.with(DayOfWeek.SUNDAY);
+
+
+        List<RecordEntry> records =
+                homeRecordRepository.findByMemberIdAndRecordDateBetween(
+                        //  ️이번 주 동안 사용자가 작성한 모든 기록 조회 recordDate 기준
+                        memberId, monday, sunday
+                );
+
+        //기록을 요일(DayOfWeek) 기준으로 그룹핑
+        Map<DayOfWeek, List<RecordEntry>> grouped =
+                records.stream()
+                        .collect(Collectors.groupingBy(
+                                r -> r.getRecordDate().getDayOfWeek()
+                        ));
+
+        //월요일 ~ 일요일 순서로 위클리 무드 응답 생성
+        List<HomeWeeklyMoodRes.DayMood> days = new ArrayList<>();
+
+        for (DayOfWeek day : DayOfWeek.values()) {
+
+            // 해당 요일의 기록 목록 (없으면 빈 리스트로 반환)
+            List<RecordEntry> dayRecords =
+                    grouped.getOrDefault(day, List.of());
+
+            //해당 요일에 기록이 없는 경우 null, false로 설정
+            if (dayRecords.isEmpty()) {
+                days.add(HomeWeeklyMoodRes.DayMood.builder()
+                        .dayOfWeek(day.name().substring(0, 3))
+                        .hasRecord(false)
+                        .emotion(null)
+                        .build());
+                continue;
+            }
+
+            //해당 요일에 여러 개의 기록이 있는 경우 가장 마지막(createdAt 기준) 기록을 선택
+            RecordEntry lastRecord =
+                    dayRecords.stream()
+                            .max(Comparator.comparing(RecordEntry::getCreatedAt))
+                            .orElseThrow();
+
+            days.add(HomeWeeklyMoodRes.DayMood.builder()
+                    .dayOfWeek(day.name().substring(0, 3))
+                    .hasRecord(true)
+                    .emotion(lastRecord.getEmotionCode())
+                    .build());
+        }
+
+
+        return HomeWeeklyMoodRes.builder()
+                .days(days)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/finly/global/config/security/SecurityConfig.java
@@ -94,6 +94,7 @@ public class SecurityConfig {
                         // PROTECTED
                         .requestMatchers("/api/analysis/**").authenticated()
                         .requestMatchers("/api/mypage/**").authenticated()
+                        .requestMatchers("/api/home/**").authenticated()
                         .requestMatchers(retestMatcher).authenticated()
 
                         // 나머지


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #99 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 홈 메인 화면에서 사용자의 이번 주 위클리 무드 조회 API 구현
- RecordEntry.recordDate를 기준으로 요일(MON~SUN)별 감정 요약
- 하루에 기록이 여러 개인 경우 → 해당 요일의 마지막 기록(createdAt 기준) 을 대표 감정으로 사용
-  기록이 없는 요일도 응답에 포함하여 프론트에서 비활성 요일 처리 가능하도록 설계했습니다! 


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="841" height="687" alt="image" src="https://github.com/user-attachments/assets/ce6079e6-9c1a-4929-9e52-6c8fd68e7e2d" />


- 위클리 무드 조회 API 정상 응답 확인
- - 기록이 없는 요일은 hasRecord = false로 반환됨
- - 기록이 있는 요일은 대표 감정(emotionCode) 정상 반환됨

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.


## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 주간 감정 조회 기능 추가: 현재 주의 월~일 각 요일별로 감정 기록 여부와 대표 감정 정보를 확인할 수 있습니다.
- **보안**
  - 홈 관련 API 접근에 인증 요구 추가: 홈 화면의 주간 감정 조회는 로그인된 사용자만 이용 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->