### PR TITLE
[Refactor] 종목명 검색 최소 검색어 길이 검증 삭제

### DIFF
--- a/src/main/java/com/umc/finly/domain/market/stock/search/exception/StockSearchErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/market/stock/search/exception/StockSearchErrorCode.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum StockSearchErrorCode implements BaseCode {
-    INVALID_KEYWORD(HttpStatus.BAD_REQUEST, "STOCK_SEARCH400", "검색어는 최소 2글자 이상이어야 합니다."),
     EMPTY_KEYWORD(HttpStatus.BAD_REQUEST, "STOCK_SEARCH400", "검색어가 비어 있습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/finly/domain/market/stock/search/exception/StockSearchErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/market/stock/search/exception/StockSearchErrorCode.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum StockSearchErrorCode implements BaseCode {
+
     EMPTY_KEYWORD(HttpStatus.BAD_REQUEST, "STOCK_SEARCH400", "검색어가 비어 있습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/finly/domain/market/stock/search/service/StockSearchServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/market/stock/search/service/StockSearchServiceImpl.java
@@ -19,8 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class StockSearchServiceImpl implements StockSearchService {
 
-    private static final int MIN_KEYWORD_LENGTH = 2;
-
     private final StockRepository stockRepository;
     private final StockSearchConverter stockSearchConverter;
 
@@ -50,10 +48,6 @@ public class StockSearchServiceImpl implements StockSearchService {
 
         if (trimmed.isEmpty()) {
             throw new StockSearchException(StockSearchErrorCode.EMPTY_KEYWORD);
-        }
-
-        if (trimmed.length() < MIN_KEYWORD_LENGTH) {
-            throw new StockSearchException(StockSearchErrorCode.INVALID_KEYWORD);
         }
 
         return trimmed;


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #104 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

종목명 검색 로직에서 최소 검색어(2글자 이상) 검증을 삭제하여 1글자부터 검색 가능하도록 수정
- StockSearchErrorCode에서 INVALID_KEYWORD 삭제
- StockSearchServiceImpl에서 MIN_KEYWORD_LENGTH 삭제, validateKeyword 메서드에서 검색어 최소 길이 검증하고 에러 발생시키는 로직 삭제


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<검색어가 1글자일 때>

- Before
<img width="1259" height="172" alt="image" src="https://github.com/user-attachments/assets/4375a2f5-a145-4b29-bfd1-d775d3c7d483" />
 
- After
<img width="1255" height="490" alt="image" src="https://github.com/user-attachments/assets/56bcaab9-fa00-4b81-99b4-3e1699c4ce55" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.