### PR TITLE
[Feat] 사용자가 기록한 종목 조회 API 

### DIFF
--- a/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisRecordController.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisRecordController.java
@@ -51,12 +51,12 @@ public class AssociationAnalysisRecordController {
                                               "result": [
                                                 {
                                                   "stockId": 123,
-                                                  "stockCode": "005930",
+                                                  "symbol": "005930",
                                                   "stockName": "삼성전자"
                                                 },
                                                 {
                                                   "stockId": 124,
-                                                  "stockCode": "000660",
+                                                  "symbol": "000660",
                                                   "stockName": "SK하이닉스"
                                                 }
                                               ]

--- a/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisRecordController.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisRecordController.java
@@ -1,0 +1,79 @@
+package com.umc.finly.domain.analysis.association.controller;
+
+
+import com.umc.finly.domain.analysis.association.dto.StockRecordResDTO;
+import com.umc.finly.domain.analysis.association.service.AssociationAnalysisService;
+import com.umc.finly.global.apiPayload.response.ApiResponse;
+import com.umc.finly.global.apiPayload.response.SuccessCode;
+import com.umc.finly.global.config.security.AuthPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "연관 분석 - 기록", description = "사용자 기록 기반 종목 조회 API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/analysis")
+public class AssociationAnalysisRecordController {
+
+    private final AssociationAnalysisService associationAnalysisService;
+    @Operation(
+            summary = "사용자가 기록한 종목 목록 조회",
+            description = """
+                    사용자가 매매 기록을 남긴 적이 있는 종목 목록을 조회합니다.
+
+                    - 동일 종목을 여러 번 기록했더라도 종목당 1회만 반환됩니다.
+                    - 사용자 인증 정보(JWT)를 기반으로 조회합니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "사용자가 기록한 종목 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "성공 응답 예시",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "ANALYSIS200",
+                                              "message": "사용자가 기록한 종목 목록을 정상적으로 조회했습니다.",
+                                              "result": [
+                                                {
+                                                  "stockId": 123,
+                                                  "stockCode": "005930",
+                                                  "stockName": "삼성전자"
+                                                },
+                                                {
+                                                  "stockId": 124,
+                                                  "stockCode": "000660",
+                                                  "stockName": "SK하이닉스"
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    @GetMapping("/record/stocks") //사용자 종목 기록 조회 API
+    public ApiResponse<List<StockRecordResDTO>> getRecordStocks(
+            @AuthenticationPrincipal AuthPrincipal principal
+    ) {
+        return ApiResponse.onSuccess(
+                associationAnalysisService.getRecordedStocks(principal.getMemberId()),
+                SuccessCode.OK
+        );
+    }
+
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisRecordController.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisRecordController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-@Tag(name = "연관 분석 - 기록", description = "사용자 기록 기반 종목 조회 API")
+@Tag(name = "AssociationAnalysisRecord", description = "사용자 기록 기반 종목 조회 API")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/analysis")

--- a/src/main/java/com/umc/finly/domain/analysis/association/dto/StockRecordResDTO.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/dto/StockRecordResDTO.java
@@ -1,0 +1,18 @@
+package com.umc.finly.domain.analysis.association.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StockRecordResDTO {
+    private Long stockId; // 종목 아이디
+    private String stockCode;// 종목 코드
+    private String stockName; // 종목 이름
+
+    public StockRecordResDTO(Long stockId, String stockCode, String stockName) {
+        this.stockId = stockId;
+        this.stockCode = stockCode;
+        this.stockName = stockName;
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/dto/StockRecordResDTO.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/dto/StockRecordResDTO.java
@@ -7,12 +7,12 @@ import lombok.Getter;
 @Builder
 public class StockRecordResDTO {
     private Long stockId; // 종목 아이디
-    private String stockCode;// 종목 코드
+    private String symbol;// 종목 코드
     private String stockName; // 종목 이름
 
-    public StockRecordResDTO(Long stockId, String stockCode, String stockName) {
+    public StockRecordResDTO(Long stockId, String symbol, String stockName) {
         this.stockId = stockId;
-        this.stockCode = stockCode;
+        this.symbol = symbol;
         this.stockName = stockName;
     }
 }

--- a/src/main/java/com/umc/finly/domain/analysis/association/repository/AssociationAnalysisRepository.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/repository/AssociationAnalysisRepository.java
@@ -1,0 +1,29 @@
+package com.umc.finly.domain.analysis.association.repository;
+
+import com.umc.finly.domain.analysis.association.dto.StockRecordResDTO;
+import com.umc.finly.domain.record.entity.RecordEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface AssociationAnalysisRepository
+        extends JpaRepository<RecordEntry, Long> {
+
+    @Query("""
+        select distinct new com.umc.finly.domain.analysis.association.dto.StockRecordResDTO(
+            s.id,
+            s.symbol,
+            s.name
+        )
+        from RecordEntry r
+        left join com.umc.finly.domain.market.stock.entity.Stock s
+               on r.stockId = s.id
+        where r.memberId = :memberId
+          and s.id is not null
+    """)
+    List<StockRecordResDTO> findRecordedStocks(
+            @Param("memberId") Long memberId
+    );
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/service/AssociationAnalysisService.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/service/AssociationAnalysisService.java
@@ -1,0 +1,9 @@
+package com.umc.finly.domain.analysis.association.service;
+
+import com.umc.finly.domain.analysis.association.dto.StockRecordResDTO;
+import java.util.List;
+
+public interface AssociationAnalysisService {
+    List<StockRecordResDTO> getRecordedStocks(Long memberId);
+
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/service/AssociationAnalysisServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/service/AssociationAnalysisServiceImpl.java
@@ -1,0 +1,24 @@
+
+package com.umc.finly.domain.analysis.association.service;
+
+import com.umc.finly.domain.analysis.association.dto.StockRecordResDTO;
+import com.umc.finly.domain.analysis.association.repository.AssociationAnalysisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AssociationAnalysisServiceImpl implements AssociationAnalysisService {
+
+    private final AssociationAnalysisRepository associationAnalysisRepository;
+
+    @Override
+    public List<StockRecordResDTO> getRecordedStocks(Long memberId) { //기록된 종목 조회
+        return associationAnalysisRepository.findRecordedStocks(memberId);
+    }
+
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> #112 

closes #112

## 📌 작업 내용
> 
- 사용자가 매매 기록을 남긴 종목 목록을 조회하는 API를 구현했습니다.
- 사용자의 인증 정보(JWT)에서 추출한 memberId를 기준으로 조회하도록 구성했습니다.
- 종목 정보는 Stock 테이블을 기준으로 조회하며, 종목 ID / 종목 코드 / 종목명을 응답으로 제공합니다.


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="879" height="590" alt="image" src="https://github.com/user-attachments/assets/f8215576-1e0d-4d0f-a840-9396016c3af2" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.


## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 기록된 주식 조회 API 추가
  * 인증된 사용자가 자신의 기록된 주식 목록(고유 ID, 종목 코드, 회사명)을 조회 가능
  * 조회 결과는 목록 형태로 반환되어 UI에서 간편하게 표시 가능
<!-- end of auto-generated comment: release notes by coderabbit.ai -->