### PR TITLE
[Refactor] 마켓 도메인 리펙토링   

### DIFF
--- a/src/main/java/com/umc/finly/domain/market/controller/MarketController.java
+++ b/src/main/java/com/umc/finly/domain/market/controller/MarketController.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-
 @RestController
 @RequestMapping("/api/markets")
 @RequiredArgsConstructor
@@ -58,7 +57,6 @@ public class MarketController {
                     )
             )
     })
-
 
 
     @GetMapping("/index")
@@ -106,6 +104,7 @@ public class MarketController {
                     )
             )
     })
+
     // 실시간 인사이트 조회
     @GetMapping("/insight")
     public ApiResponse<MarketInsightResDTO> getInsightMarketIndex() {

--- a/src/main/java/com/umc/finly/domain/market/controller/MarketController.java
+++ b/src/main/java/com/umc/finly/domain/market/controller/MarketController.java
@@ -17,7 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @RestController
 @RequestMapping("/api/markets")
 @RequiredArgsConstructor
-@Tag(name = "market", description = "시장 지수 및 실시간 시장 인사이트 API")
+@Tag(name = "Market", description = "시장 지수 및 실시간 시장 인사이트 API")
 public class MarketController {
     private final MarketIndexService marketIndexService;
     private final MarketInsightService marketInsightService;

--- a/src/main/java/com/umc/finly/domain/market/controller/MarketController.java
+++ b/src/main/java/com/umc/finly/domain/market/controller/MarketController.java
@@ -1,20 +1,65 @@
 package com.umc.finly.domain.market.controller;
 
-import com.umc.finly.domain.market.dto.MarketIndexResDTO;
-import com.umc.finly.domain.market.dto.MarketInsightResDTO;
+import com.umc.finly.domain.market.dto.res.MarketIndexResDTO;
+import com.umc.finly.domain.market.dto.res.MarketInsightResDTO;
 import com.umc.finly.domain.market.service.MarketIndexService;
 import com.umc.finly.domain.market.service.MarketInsightService;
 import com.umc.finly.global.apiPayload.response.ApiResponse;
 import com.umc.finly.global.apiPayload.response.SuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 
 @RestController
-@RequestMapping("/api/market")
+@RequestMapping("/api/markets")
 @RequiredArgsConstructor
+@Tag(name = "market", description = "시장 지수 및 실시간 시장 인사이트 API")
 public class MarketController {
     private final MarketIndexService marketIndexService;
     private final MarketInsightService marketInsightService;
+    @Operation(
+            summary = "시장 지수 조회",
+            description = """
+                    현재 시장 지표 정보를 조회합니다.
+                    
+                    - KOSPI / KOSDAQ 지수
+                    - 공포·탐욕 지수 및 상태
+                    - 마지막 업데이트 시각
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "시장 지수 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "시장 지수 응답 예시",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "COMMON200",
+                                              "message": "요청에 성공했습니다.",
+                                              "result": {
+                                                "kospi": 5088.79,
+                                                "kosdaq": 1078.5,
+                                                "fearGreed": 33,
+                                                "fearGreedStatus": "FEAR",
+                                                "updatedAt": "2026-02-06T15:03:27"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+
+
 
     @GetMapping("/index")
     public ApiResponse<MarketIndexResDTO> getMarketIndex() {
@@ -24,6 +69,43 @@ public class MarketController {
                 SuccessCode.OK
         );
     }
+
+    @Operation(
+            summary = "실시간 시장 인사이트 조회",
+            description = """
+                    특정 종목을 중심으로 한 실시간 시장 인사이트를 조회합니다.
+                    
+                    - 현재 시장 참여자의 감정 상태
+                    - 매수/매도 우세 비율
+                    - 신뢰도 레벨
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "실시간 시장 인사이트 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "시장 인사이트 응답 예시",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "COMMON200",
+                                              "message": "요청에 성공했습니다.",
+                                              "result": {
+                                                "stockName": "삼성전자",
+                                                "message": "지금 삼성전자 주주들은 욕심이 커진 상태예요",
+                                                "dominantEmotion": "GREED",
+                                                "buySellRatio": "BUY_DOMINANT",
+                                                "confidenceLevel": "LOW"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     // 실시간 인사이트 조회
     @GetMapping("/insight")
     public ApiResponse<MarketInsightResDTO> getInsightMarketIndex() {
@@ -32,6 +114,5 @@ public class MarketController {
                 SuccessCode.OK
         );
     }
-
 
 }

--- a/src/main/java/com/umc/finly/domain/market/dto/res/FearGreedResDTO.java
+++ b/src/main/java/com/umc/finly/domain/market/dto/res/FearGreedResDTO.java
@@ -1,4 +1,4 @@
-package com.umc.finly.domain.market.dto;
+package com.umc.finly.domain.market.dto.res;
 
 import com.umc.finly.domain.market.enums.FearGreedStatus;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/umc/finly/domain/market/dto/res/MarketIndexResDTO.java
+++ b/src/main/java/com/umc/finly/domain/market/dto/res/MarketIndexResDTO.java
@@ -1,4 +1,4 @@
-package com.umc.finly.domain.market.dto;
+package com.umc.finly.domain.market.dto.res;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;

--- a/src/main/java/com/umc/finly/domain/market/dto/res/MarketIndicesDTO.java
+++ b/src/main/java/com/umc/finly/domain/market/dto/res/MarketIndicesDTO.java
@@ -1,4 +1,4 @@
-package com.umc.finly.domain.market.dto;
+package com.umc.finly.domain.market.dto.res;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/umc/finly/domain/market/dto/res/MarketInsightResDTO.java
+++ b/src/main/java/com/umc/finly/domain/market/dto/res/MarketInsightResDTO.java
@@ -1,4 +1,4 @@
-package com.umc.finly.domain.market.dto;
+package com.umc.finly.domain.market.dto.res;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/umc/finly/domain/market/infra/CnnFearGreedIndexProvider.java
+++ b/src/main/java/com/umc/finly/domain/market/infra/CnnFearGreedIndexProvider.java
@@ -2,7 +2,7 @@ package com.umc.finly.domain.market.infra;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umc.finly.domain.market.dto.FearGreedResDTO;
+import com.umc.finly.domain.market.dto.res.FearGreedResDTO;
 import com.umc.finly.domain.market.enums.FearGreedStatus;
 import com.umc.finly.domain.market.exception.code.MarketErrorCode;
 import com.umc.finly.global.apiPayload.exception.CustomException;

--- a/src/main/java/com/umc/finly/domain/market/infra/FearGreedIndexProvider.java
+++ b/src/main/java/com/umc/finly/domain/market/infra/FearGreedIndexProvider.java
@@ -1,6 +1,6 @@
 package com.umc.finly.domain.market.infra;
 
-import com.umc.finly.domain.market.dto.FearGreedResDTO;
+import com.umc.finly.domain.market.dto.res.FearGreedResDTO;
 
 public interface FearGreedIndexProvider {
     FearGreedResDTO getFearGreedIndex();

--- a/src/main/java/com/umc/finly/domain/market/infra/MarketIndexProvider.java
+++ b/src/main/java/com/umc/finly/domain/market/infra/MarketIndexProvider.java
@@ -1,6 +1,6 @@
 package com.umc.finly.domain.market.infra;
 
-import com.umc.finly.domain.market.dto.MarketIndicesDTO;
+import com.umc.finly.domain.market.dto.res.MarketIndicesDTO;
 
 public interface MarketIndexProvider {
     MarketIndicesDTO getMarketIndices();

--- a/src/main/java/com/umc/finly/domain/market/infra/NaverMarketIndexProvider.java
+++ b/src/main/java/com/umc/finly/domain/market/infra/NaverMarketIndexProvider.java
@@ -2,7 +2,7 @@ package com.umc.finly.domain.market.infra;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umc.finly.domain.market.dto.MarketIndicesDTO;
+import com.umc.finly.domain.market.dto.res.MarketIndicesDTO;
 import com.umc.finly.domain.market.exception.code.MarketErrorCode;
 import com.umc.finly.global.apiPayload.exception.CustomException;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/src/main/java/com/umc/finly/domain/market/service/MarketCacheService.java
+++ b/src/main/java/com/umc/finly/domain/market/service/MarketCacheService.java
@@ -1,4 +1,0 @@
-package com.umc.finly.domain.market.service;
-
-public class MarketCacheService {
-}

--- a/src/main/java/com/umc/finly/domain/market/service/MarketCrawlingService.java
+++ b/src/main/java/com/umc/finly/domain/market/service/MarketCrawlingService.java
@@ -1,4 +1,0 @@
-package com.umc.finly.domain.market.service;
-
-public class MarketCrawlingService {
-}

--- a/src/main/java/com/umc/finly/domain/market/service/MarketIndexService.java
+++ b/src/main/java/com/umc/finly/domain/market/service/MarketIndexService.java
@@ -1,8 +1,8 @@
 package com.umc.finly.domain.market.service;
 
-import com.umc.finly.domain.market.dto.FearGreedResDTO;
-import com.umc.finly.domain.market.dto.MarketIndexResDTO;
-import com.umc.finly.domain.market.dto.MarketIndicesDTO;
+import com.umc.finly.domain.market.dto.res.FearGreedResDTO;
+import com.umc.finly.domain.market.dto.res.MarketIndexResDTO;
+import com.umc.finly.domain.market.dto.res.MarketIndicesDTO;
 import com.umc.finly.domain.market.infra.FearGreedIndexProvider;
 import com.umc.finly.domain.market.infra.MarketIndexProvider;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/umc/finly/domain/market/service/MarketInsightService.java
+++ b/src/main/java/com/umc/finly/domain/market/service/MarketInsightService.java
@@ -1,6 +1,6 @@
 package com.umc.finly.domain.market.service;
 
-import com.umc.finly.domain.market.dto.MarketInsightResDTO;
+import com.umc.finly.domain.market.dto.res.MarketInsightResDTO;
 import com.umc.finly.domain.market.repository.MarketInsightRepository;
 import com.umc.finly.domain.market.repository.projection.StockEmotionBuyAggregation;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## 🔗 관련 이슈
> #67 

closes #67

## 📌 작업 내용
> 
- 마켓도메인 url 수정 =>  market-> markets로 수정했습니다
- DTO 폴더 추가 -> dto.res 에 dto 파일 옮겼습니다
- 스웨거 코드 추가   


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="1439" height="183" alt="image" src="https://github.com/user-attachments/assets/f583aabc-4250-4579-a13a-2e82dfb52f90" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서 개선**
  * 마켓 관련 API 엔드포인트에 대한 Swagger/OpenAPI 문서 강화로 API 명세 가시성 개선

* **리팩토링**
  * API 엔드포인트 경로 변경 (`/api/market` → `/api/markets`)
  * 내부 코드 구조 및 패키지 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->