### PR TITLE
[Feat] 약관 상세 조회 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/auth/controller/TermController.java
+++ b/src/main/java/com/umc/finly/domain/auth/controller/TermController.java
@@ -1,5 +1,6 @@
 package com.umc.finly.domain.auth.controller;
 
+import com.umc.finly.domain.auth.dto.res.TermDetailResDTO;
 import com.umc.finly.domain.auth.dto.res.TermResDTO;
 import com.umc.finly.domain.auth.service.TermQueryService;
 import com.umc.finly.global.apiPayload.response.ApiResponse;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,5 +37,19 @@ public class TermController {
     @GetMapping
     public ApiResponse<TermResDTO.TermList> getTerms(){
         return ApiResponse.onSuccess(termQueryService.getTerms(), SuccessCode.OK);
+    }
+
+    @Operation(
+            summary = "약관 상세 조회",
+            description = """
+                약관 ID로 약관 상세(제목/본문)를 조회합니다.
+                
+                - 로그인 없이 접근 가능하도록 permitAll 권장
+                - 약관 종류(termType)도 함께 반환합니다.
+                """
+    )
+    @GetMapping("/{termId}")
+    public ApiResponse<TermDetailResDTO> getTermDetail(@PathVariable Long termId){
+        return ApiResponse.onSuccess(termQueryService.getTermDetail(termId), SuccessCode.OK);
     }
 }

--- a/src/main/java/com/umc/finly/domain/auth/controller/TermController.java
+++ b/src/main/java/com/umc/finly/domain/auth/controller/TermController.java
@@ -44,7 +44,7 @@ public class TermController {
             description = """
                 약관 ID로 약관 상세(제목/본문)를 조회합니다.
                 
-                - 로그인 없이 접근 가능하도록 permitAll 권장
+                - 로그인 없이 접근 가능
                 - 약관 종류(termType)도 함께 반환합니다.
                 """
     )

--- a/src/main/java/com/umc/finly/domain/auth/dto/res/TermDetailResDTO.java
+++ b/src/main/java/com/umc/finly/domain/auth/dto/res/TermDetailResDTO.java
@@ -1,0 +1,28 @@
+package com.umc.finly.domain.auth.dto.res;
+
+import com.umc.finly.domain.auth.entity.Term;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TermDetailResDTO {
+
+    private Long termId;
+    private String termType;
+    private String title;
+    private String content;
+
+    public static TermDetailResDTO from(Term term){
+        return TermDetailResDTO.builder()
+                .termId(term.getId())
+                .termType(term.getTermType().name())
+                .title(term.getTitle())
+                .content(term.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/auth/entity/Term.java
+++ b/src/main/java/com/umc/finly/domain/auth/entity/Term.java
@@ -23,4 +23,7 @@ public class Term extends CreatedBaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "term_type", nullable = false, length = 50, unique = true)
     private TermType termType;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
 }

--- a/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
@@ -29,6 +29,9 @@ public enum AuthErrorCode implements BaseCode {
     //403
     FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH403", "접근 권한이 없습니다."),
 
+    // 404
+    TERM_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH404", "해당 약관이 없습니다."),
+
     // 422
     REQUIRED_TERM_NOT_AGREED(HttpStatus.UNPROCESSABLE_ENTITY, "AUTH422", "필수 약관에 동의해야 합니다.");
 

--- a/src/main/java/com/umc/finly/domain/auth/service/TermQueryService.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/TermQueryService.java
@@ -1,7 +1,9 @@
 package com.umc.finly.domain.auth.service;
 
+import com.umc.finly.domain.auth.dto.res.TermDetailResDTO;
 import com.umc.finly.domain.auth.dto.res.TermResDTO;
 
 public interface TermQueryService {
     TermResDTO.TermList getTerms();
+    TermDetailResDTO getTermDetail(Long termId);
 }

--- a/src/main/java/com/umc/finly/domain/auth/service/TermQueryServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/TermQueryServiceImpl.java
@@ -1,8 +1,11 @@
 package com.umc.finly.domain.auth.service;
 
+import com.umc.finly.domain.auth.dto.res.TermDetailResDTO;
 import com.umc.finly.domain.auth.dto.res.TermResDTO;
 import com.umc.finly.domain.auth.entity.Term;
+import com.umc.finly.domain.auth.exception.AuthErrorCode;
 import com.umc.finly.domain.auth.repository.TermRepository;
+import com.umc.finly.global.apiPayload.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,5 +36,14 @@ public class TermQueryServiceImpl implements TermQueryService{
         return TermResDTO.TermList.builder()
                 .terms(items)
                 .build();
+    }
+
+    // 약관 상세 조회 -> 약관Id 로 조회
+    @Override
+    public TermDetailResDTO getTermDetail(Long termId){
+        Term term = termRepository.findById(termId)
+                .orElseThrow(()->new CustomException(AuthErrorCode.TERM_NOT_FOUND));
+
+        return TermDetailResDTO.from(term);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #116 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 약관 상세 조회 api 기능 구현


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

### 조회 성공 시
<img width="2098" height="982" alt="image" src="https://github.com/user-attachments/assets/f1ad674d-5054-4578-9be1-55aaf6eb7b38" />

### 조회 실패 시 
<img width="1036" height="578" alt="image" src="https://github.com/user-attachments/assets/cbfca0c7-2a92-4a7b-a5c2-35705339fb7d" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.
- terms 테이블에 description 콜룸 추가되었습니다. 
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 약관 상세 조회: 약관 ID를 통해 약관의 상세 정보 및 콘텐츠를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다. 사용자는 이제 특정 약관의 전체 내용을 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->