### PR TITLE
[Feat] 감정 분포 그래프 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisRecordController.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisRecordController.java
@@ -51,12 +51,12 @@ public class AssociationAnalysisRecordController {
                                               "result": [
                                                 {
                                                   "stockId": 123,
-                                                  "stockCode": "005930",
+                                                  "symbol": "005930",
                                                   "stockName": "삼성전자"
                                                 },
                                                 {
                                                   "stockId": 124,
-                                                  "stockCode": "000660",
+                                                  "symbol": "000660",
                                                   "stockName": "SK하이닉스"
                                                 }
                                               ]

--- a/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisRecordController.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisRecordController.java
@@ -1,0 +1,79 @@
+package com.umc.finly.domain.analysis.association.controller;
+
+
+import com.umc.finly.domain.analysis.association.dto.StockRecordResDTO;
+import com.umc.finly.domain.analysis.association.service.AssociationAnalysisService;
+import com.umc.finly.global.apiPayload.response.ApiResponse;
+import com.umc.finly.global.apiPayload.response.SuccessCode;
+import com.umc.finly.global.config.security.AuthPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "연관 분석 - 기록", description = "사용자 기록 기반 종목 조회 API")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/analysis")
+public class AssociationAnalysisRecordController {
+
+    private final AssociationAnalysisService associationAnalysisService;
+    @Operation(
+            summary = "사용자가 기록한 종목 목록 조회",
+            description = """
+                    사용자가 매매 기록을 남긴 적이 있는 종목 목록을 조회합니다.
+
+                    - 동일 종목을 여러 번 기록했더라도 종목당 1회만 반환됩니다.
+                    - 사용자 인증 정보(JWT)를 기반으로 조회합니다.
+                    """
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "사용자가 기록한 종목 목록 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "성공 응답 예시",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "ANALYSIS200",
+                                              "message": "사용자가 기록한 종목 목록을 정상적으로 조회했습니다.",
+                                              "result": [
+                                                {
+                                                  "stockId": 123,
+                                                  "stockCode": "005930",
+                                                  "stockName": "삼성전자"
+                                                },
+                                                {
+                                                  "stockId": 124,
+                                                  "stockCode": "000660",
+                                                  "stockName": "SK하이닉스"
+                                                }
+                                              ]
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+    @GetMapping("/record/stocks") //사용자 종목 기록 조회 API
+    public ApiResponse<List<StockRecordResDTO>> getRecordStocks(
+            @AuthenticationPrincipal AuthPrincipal principal
+    ) {
+        return ApiResponse.onSuccess(
+                associationAnalysisService.getRecordedStocks(principal.getMemberId()),
+                SuccessCode.OK
+        );
+    }
+
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisRecordController.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisRecordController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-@Tag(name = "연관 분석 - 기록", description = "사용자 기록 기반 종목 조회 API")
+@Tag(name = "AssociationAnalysisRecord", description = "사용자 기록 기반 종목 조회 API")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/analysis")

--- a/src/main/java/com/umc/finly/domain/analysis/association/dto/StockRecordResDTO.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/dto/StockRecordResDTO.java
@@ -1,0 +1,18 @@
+package com.umc.finly.domain.analysis.association.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class StockRecordResDTO {
+    private Long stockId; // 종목 아이디
+    private String stockCode;// 종목 코드
+    private String stockName; // 종목 이름
+
+    public StockRecordResDTO(Long stockId, String stockCode, String stockName) {
+        this.stockId = stockId;
+        this.stockCode = stockCode;
+        this.stockName = stockName;
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/dto/StockRecordResDTO.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/dto/StockRecordResDTO.java
@@ -7,12 +7,12 @@ import lombok.Getter;
 @Builder
 public class StockRecordResDTO {
     private Long stockId; // 종목 아이디
-    private String stockCode;// 종목 코드
+    private String symbol;// 종목 코드
     private String stockName; // 종목 이름
 
-    public StockRecordResDTO(Long stockId, String stockCode, String stockName) {
+    public StockRecordResDTO(Long stockId, String symbol, String stockName) {
         this.stockId = stockId;
-        this.stockCode = stockCode;
+        this.symbol = symbol;
         this.stockName = stockName;
     }
 }

--- a/src/main/java/com/umc/finly/domain/analysis/association/repository/AssociationAnalysisRepository.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/repository/AssociationAnalysisRepository.java
@@ -1,0 +1,29 @@
+package com.umc.finly.domain.analysis.association.repository;
+
+import com.umc.finly.domain.analysis.association.dto.StockRecordResDTO;
+import com.umc.finly.domain.record.entity.RecordEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface AssociationAnalysisRepository
+        extends JpaRepository<RecordEntry, Long> {
+
+    @Query("""
+        select distinct new com.umc.finly.domain.analysis.association.dto.StockRecordResDTO(
+            s.id,
+            s.symbol,
+            s.name
+        )
+        from RecordEntry r
+        left join com.umc.finly.domain.market.stock.entity.Stock s
+               on r.stockId = s.id
+        where r.memberId = :memberId
+          and s.id is not null
+    """)
+    List<StockRecordResDTO> findRecordedStocks(
+            @Param("memberId") Long memberId
+    );
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/service/AssociationAnalysisService.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/service/AssociationAnalysisService.java
@@ -1,0 +1,9 @@
+package com.umc.finly.domain.analysis.association.service;
+
+import com.umc.finly.domain.analysis.association.dto.StockRecordResDTO;
+import java.util.List;
+
+public interface AssociationAnalysisService {
+    List<StockRecordResDTO> getRecordedStocks(Long memberId);
+
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/service/AssociationAnalysisServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/service/AssociationAnalysisServiceImpl.java
@@ -1,0 +1,24 @@
+
+package com.umc.finly.domain.analysis.association.service;
+
+import com.umc.finly.domain.analysis.association.dto.StockRecordResDTO;
+import com.umc.finly.domain.analysis.association.repository.AssociationAnalysisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AssociationAnalysisServiceImpl implements AssociationAnalysisService {
+
+    private final AssociationAnalysisRepository associationAnalysisRepository;
+
+    @Override
+    public List<StockRecordResDTO> getRecordedStocks(Long memberId) { //기록된 종목 조회
+        return associationAnalysisRepository.findRecordedStocks(memberId);
+    }
+
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/DTO/response/EmotionDistributionResDTO.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/DTO/response/EmotionDistributionResDTO.java
@@ -1,0 +1,38 @@
+package com.umc.finly.domain.analysis.emotion.DTO.response;
+
+import com.umc.finly.domain.record.enums.EmotionCode;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmotionDistributionResDTO {
+
+    private int totalCount;                   // 전체 기록 개수
+    private SelectedStock stock;
+    private List<TypeSummary> typeSummary;    // 감정 타입 별 요약 정보 리스트
+
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SelectedStock{
+        private String symbol;
+        private String stockName;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TypeSummary {
+        private EmotionCode type;             // 감정 타입 : ANXIETY, GREED, CALM, CONFIDENCE, REGRET
+        private long count;                   // 해당 감정의 기록 개수
+        private int percent;                  // 전체 대비 비율 (정수, 합 100%)
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/Repository/EmotionAnalysisRepository.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/Repository/EmotionAnalysisRepository.java
@@ -1,0 +1,31 @@
+package com.umc.finly.domain.analysis.emotion.Repository;
+
+import com.umc.finly.domain.record.entity.RecordEntry;
+import com.umc.finly.domain.record.enums.EmotionCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface EmotionAnalysisRepository extends JpaRepository<RecordEntry, Long> {
+
+    // 회원의 기록을 감정 타입(emotionCode) 기준으로 그룹핑하여 개수 집계
+    @Query("""
+        select r.emotionCode as emotionCode, count(r) as count
+        from RecordEntry r
+        where r.memberId = :memberId
+            and r.stockId = :stockId
+        group by r.emotionCode
+    """)
+    List<EmotionCountProjection> countGroupByEmotionCode(@Param("memberId") Long memberId, @Param("stockId") Long stockId);
+
+
+    // ===== Projection interfaces =====
+
+    // 감정 타입별 개수 조회 결과를 받기 위한 Projection
+    interface EmotionCountProjection {
+        EmotionCode getEmotionCode();
+        Long getCount();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/Service/EmotionAnalysisService.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/Service/EmotionAnalysisService.java
@@ -1,0 +1,7 @@
+package com.umc.finly.domain.analysis.emotion.Service;
+
+import com.umc.finly.domain.analysis.emotion.DTO.response.EmotionDistributionResDTO;
+
+public interface EmotionAnalysisService {
+    EmotionDistributionResDTO getEmotionDistribution(Long memberId,String symbol);  // 감정 분포 그래프
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/Service/EmotionAnalysisServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/Service/EmotionAnalysisServiceImpl.java
@@ -1,0 +1,151 @@
+package com.umc.finly.domain.analysis.emotion.Service;
+
+import com.umc.finly.domain.analysis.emotion.DTO.response.EmotionDistributionResDTO;
+import com.umc.finly.domain.analysis.emotion.converter.EmotionAnalysisConverter;
+import com.umc.finly.domain.analysis.emotion.Repository.EmotionAnalysisRepository;
+import com.umc.finly.domain.analysis.emotion.exception.code.EmotionAnalysisErrorCode;
+import com.umc.finly.domain.market.stock.entity.Stock;
+import com.umc.finly.domain.market.stock.repository.StockRepository;
+import com.umc.finly.domain.record.enums.EmotionCode;
+import com.umc.finly.domain.record.exception.code.RecordErrorCode;
+import com.umc.finly.global.apiPayload.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmotionAnalysisServiceImpl implements EmotionAnalysisService {
+
+    private final StockRepository stockRepository;
+    private final EmotionAnalysisRepository emotionAnalysisRepository;
+    private final EmotionAnalysisConverter emotionAnalysisConverter;
+
+    @Override
+    public EmotionDistributionResDTO getEmotionDistribution(Long memberId, String symbol) {
+
+        // memberId가 없으면 잘못된 요청으로 처리
+        if (memberId == null) {
+            throw new CustomException(RecordErrorCode.RECORD_INVALID_REQUEST);
+        }
+
+        // symbol로 Stock을 찾아서 stockId/stockName 확보
+        Stock stock = stockRepository.findBySymbol(symbol)
+                .orElseThrow(() -> new CustomException(EmotionAnalysisErrorCode.ANALYSIS_STOCK_NOT_FOUND));
+        // // 너희 프로젝트에 맞는 "종목 없음" 에러코드로 교체해줘
+
+        // 종목 DTO 생성
+        EmotionDistributionResDTO.SelectedStock stockDto =
+                EmotionDistributionResDTO.SelectedStock.builder()
+                        .symbol(stock.getSymbol())
+                        .stockName(stock.getName())
+                        .build();
+
+        // 감정별 count 집계 조회
+        List<EmotionAnalysisRepository.EmotionCountProjection> projections =
+                emotionAnalysisRepository.countGroupByEmotionCode(memberId, stock.getId());
+
+        // emotionCode -> count 맵으로 변환
+        Map<EmotionCode, Long> countMap = new EnumMap<>(EmotionCode.class);
+        long totalCount = 0;
+
+        for (EmotionAnalysisRepository.EmotionCountProjection p : projections) {
+            // null 방어해서 count 추출
+            long count = (p.getCount() == null) ? 0L : p.getCount();
+
+            // 감정별 count 저장
+            countMap.put(p.getEmotionCode(), count);
+
+            // 전체 개수 누적
+            totalCount += count;
+        }
+
+        // 모든 EmotionCode를 포함하는 summary 리스트 생성(0건도 포함)
+        List<EmotionDistributionResDTO.TypeSummary> summaries = new ArrayList<>();
+
+        // percent 합계와 최댓값(보정 대상) 추적
+        int sumPercent = 0;
+        EmotionCode maxType = null;
+        long maxCount = -1;
+
+        for (EmotionCode code : EmotionCode.values()) {
+            // 해당 감정 count 가져오기(없으면 0)
+            long count = countMap.getOrDefault(code, 0L);
+
+            // 가장 count 큰 감정 찾기(나중에 remain 보정)
+            if (maxType == null || count > maxCount) {
+                maxType = code;
+                maxCount = count;
+            }
+
+            // percent 계산(버림)
+            int percent = 0;
+            if (totalCount > 0) {
+                percent = (int) ((count * 100) / totalCount);
+            }
+
+            // percent 합 누적
+            sumPercent += percent;
+
+            // TypeSummary 생성
+            summaries.add(EmotionDistributionResDTO.TypeSummary.builder()
+                    .type(code)
+                    .count(count)
+                    .percent(percent)
+                    .build());
+        }
+
+        // percent 합이 100이 되도록 보정 (분배 방식)
+        adjustPercentTo100(totalCount, summaries);
+
+        // Converter로 최종 응답 조립
+        return emotionAnalysisConverter.toEmotionDistributionResDTO(
+                totalCount,
+                stockDto,
+                summaries
+        );
+    }
+
+    // percent 합이 100이 되도록 보정하는 메서드
+    private void adjustPercentTo100(long totalCount, List<EmotionDistributionResDTO.TypeSummary> summaries) {
+        // 기록이 0개면 모두 0%로 두고 종료
+        if (totalCount == 0 || summaries == null || summaries.isEmpty()) {
+            return;
+        }
+
+        // percent 총합 계산
+        int sum = 0;
+        for (EmotionDistributionResDTO.TypeSummary s : summaries) {
+            sum += s.getPercent();
+        }
+
+        int diff = 100 - sum;
+
+        // 보정할 필요가 없으면 종료
+        if (diff == 0) {
+            return;
+        }
+
+        if (diff > 0) {
+            // 퍼센트가 부족한 경우: count 큰 순서대로 +1
+            summaries.sort((a, b) -> Long.compare(b.getCount(), a.getCount()));
+
+            for (int i = 0; i < diff; i++) {
+                EmotionDistributionResDTO.TypeSummary target = summaries.get(i % summaries.size());
+                target.setPercent(target.getPercent() + 1);
+            }
+        } else {
+            // 퍼센트가 초과한 경우: count 작은 순서대로 -1
+            summaries.sort((a, b) -> Long.compare(a.getCount(), b.getCount()));
+
+            int remaining = -diff;
+            int attempts = 0;
+        }
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/Service/EmotionAnalysisServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/Service/EmotionAnalysisServiceImpl.java
@@ -38,7 +38,6 @@ public class EmotionAnalysisServiceImpl implements EmotionAnalysisService {
         // symbol로 Stock을 찾아서 stockId/stockName 확보
         Stock stock = stockRepository.findBySymbol(symbol)
                 .orElseThrow(() -> new CustomException(EmotionAnalysisErrorCode.ANALYSIS_STOCK_NOT_FOUND));
-        // // 너희 프로젝트에 맞는 "종목 없음" 에러코드로 교체해줘
 
         // 종목 DTO 생성
         EmotionDistributionResDTO.SelectedStock stockDto =
@@ -69,29 +68,15 @@ public class EmotionAnalysisServiceImpl implements EmotionAnalysisService {
         // 모든 EmotionCode를 포함하는 summary 리스트 생성(0건도 포함)
         List<EmotionDistributionResDTO.TypeSummary> summaries = new ArrayList<>();
 
-        // percent 합계와 최댓값(보정 대상) 추적
-        int sumPercent = 0;
-        EmotionCode maxType = null;
-        long maxCount = -1;
-
         for (EmotionCode code : EmotionCode.values()) {
             // 해당 감정 count 가져오기(없으면 0)
             long count = countMap.getOrDefault(code, 0L);
-
-            // 가장 count 큰 감정 찾기(나중에 remain 보정)
-            if (maxType == null || count > maxCount) {
-                maxType = code;
-                maxCount = count;
-            }
 
             // percent 계산(버림)
             int percent = 0;
             if (totalCount > 0) {
                 percent = (int) ((count * 100) / totalCount);
             }
-
-            // percent 합 누적
-            sumPercent += percent;
 
             // TypeSummary 생성
             summaries.add(EmotionDistributionResDTO.TypeSummary.builder()

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/controller/EmotionAnalysisController.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/controller/EmotionAnalysisController.java
@@ -7,6 +7,7 @@ import com.umc.finly.global.apiPayload.response.ApiResponse;
 import com.umc.finly.global.apiPayload.response.ErrorCode;
 import com.umc.finly.global.apiPayload.response.SuccessCode;
 import com.umc.finly.global.config.security.AuthPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,6 +24,7 @@ public class EmotionAnalysisController {
 
     private final EmotionAnalysisService emotionAnalysisService;
 
+    @Operation(summary = "감정 분포 그래프 API", description = "각 종목의 조각 감정 분포 통계")
     @GetMapping("/{symbol}/emotion-distribution")
     public ApiResponse<EmotionDistributionResDTO> getEmotionDistribution(
             @AuthenticationPrincipal AuthPrincipal principal,

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/controller/EmotionAnalysisController.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/controller/EmotionAnalysisController.java
@@ -1,0 +1,40 @@
+package com.umc.finly.domain.analysis.emotion.controller;
+
+import com.umc.finly.domain.analysis.emotion.DTO.response.EmotionDistributionResDTO;
+import com.umc.finly.domain.analysis.emotion.Service.EmotionAnalysisService;
+import com.umc.finly.global.apiPayload.exception.CustomException;
+import com.umc.finly.global.apiPayload.response.ApiResponse;
+import com.umc.finly.global.apiPayload.response.ErrorCode;
+import com.umc.finly.global.apiPayload.response.SuccessCode;
+import com.umc.finly.global.config.security.AuthPrincipal;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@Tag(name = "Analysis - emotion", description = "통계 감정 분석 API")
+@RequestMapping("/api/analysis/stocks")
+public class EmotionAnalysisController {
+
+    private final EmotionAnalysisService emotionAnalysisService;
+
+    @GetMapping("/{symbol}/emotion-distribution")
+    public ApiResponse<EmotionDistributionResDTO> getEmotionDistribution(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @PathVariable String symbol
+    ) {
+        if(principal == null){
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        EmotionDistributionResDTO result =
+                emotionAnalysisService.getEmotionDistribution(principal.getMemberId(), symbol);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/converter/EmotionAnalysisConverter.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/converter/EmotionAnalysisConverter.java
@@ -1,0 +1,22 @@
+package com.umc.finly.domain.analysis.emotion.converter;
+
+import com.umc.finly.domain.analysis.emotion.DTO.response.EmotionDistributionResDTO;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class EmotionAnalysisConverter {
+
+    // 감정 분포 그래프 응답 DTO 변환
+    public EmotionDistributionResDTO toEmotionDistributionResDTO(
+            long totalCount,
+            EmotionDistributionResDTO.SelectedStock stock,
+            List<EmotionDistributionResDTO.TypeSummary> summaries) {
+        return EmotionDistributionResDTO.builder()
+                .totalCount((int) totalCount)
+                .stock(stock)
+                .typeSummary(summaries)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/exception/EmotionAnalysisException.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/exception/EmotionAnalysisException.java
@@ -1,0 +1,10 @@
+package com.umc.finly.domain.analysis.emotion.exception;
+
+import com.umc.finly.global.apiPayload.exception.CustomException;
+import com.umc.finly.global.apiPayload.response.BaseCode;
+
+public class EmotionAnalysisException extends CustomException {
+    public EmotionAnalysisException(BaseCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/exception/code/EmotionAnalysisErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/exception/code/EmotionAnalysisErrorCode.java
@@ -1,0 +1,18 @@
+package com.umc.finly.domain.analysis.emotion.exception.code;
+
+import com.umc.finly.global.apiPayload.response.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum EmotionAnalysisErrorCode implements BaseCode {
+
+    // 4xx
+    ANALYSIS_STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "RECORD404_1", "종목을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/exception/code/EmotionAnalysisErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/exception/code/EmotionAnalysisErrorCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum EmotionAnalysisErrorCode implements BaseCode {
 
     // 4xx
-    ANALYSIS_STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "RECORD404_1", "종목을 찾을 수 없습니다.");
+    ANALYSIS_STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_EMOTION_404_1", "종목을 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/finly/domain/market/controller/MarketController.java
+++ b/src/main/java/com/umc/finly/domain/market/controller/MarketController.java
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-
 @RestController
 @RequestMapping("/api/markets")
 @RequiredArgsConstructor
@@ -58,7 +57,6 @@ public class MarketController {
                     )
             )
     })
-
 
 
     @GetMapping("/index")
@@ -106,6 +104,7 @@ public class MarketController {
                     )
             )
     })
+
     // 실시간 인사이트 조회
     @GetMapping("/insight")
     public ApiResponse<MarketInsightResDTO> getInsightMarketIndex() {

--- a/src/main/java/com/umc/finly/domain/market/controller/MarketController.java
+++ b/src/main/java/com/umc/finly/domain/market/controller/MarketController.java
@@ -17,7 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @RestController
 @RequestMapping("/api/markets")
 @RequiredArgsConstructor
-@Tag(name = "market", description = "시장 지수 및 실시간 시장 인사이트 API")
+@Tag(name = "Market", description = "시장 지수 및 실시간 시장 인사이트 API")
 public class MarketController {
     private final MarketIndexService marketIndexService;
     private final MarketInsightService marketInsightService;

--- a/src/main/java/com/umc/finly/domain/market/controller/MarketController.java
+++ b/src/main/java/com/umc/finly/domain/market/controller/MarketController.java
@@ -1,20 +1,65 @@
 package com.umc.finly.domain.market.controller;
 
-import com.umc.finly.domain.market.dto.MarketIndexResDTO;
-import com.umc.finly.domain.market.dto.MarketInsightResDTO;
+import com.umc.finly.domain.market.dto.res.MarketIndexResDTO;
+import com.umc.finly.domain.market.dto.res.MarketInsightResDTO;
 import com.umc.finly.domain.market.service.MarketIndexService;
 import com.umc.finly.domain.market.service.MarketInsightService;
 import com.umc.finly.global.apiPayload.response.ApiResponse;
 import com.umc.finly.global.apiPayload.response.SuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
 
 @RestController
-@RequestMapping("/api/market")
+@RequestMapping("/api/markets")
 @RequiredArgsConstructor
+@Tag(name = "market", description = "시장 지수 및 실시간 시장 인사이트 API")
 public class MarketController {
     private final MarketIndexService marketIndexService;
     private final MarketInsightService marketInsightService;
+    @Operation(
+            summary = "시장 지수 조회",
+            description = """
+                    현재 시장 지표 정보를 조회합니다.
+                    
+                    - KOSPI / KOSDAQ 지수
+                    - 공포·탐욕 지수 및 상태
+                    - 마지막 업데이트 시각
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "시장 지수 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "시장 지수 응답 예시",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "COMMON200",
+                                              "message": "요청에 성공했습니다.",
+                                              "result": {
+                                                "kospi": 5088.79,
+                                                "kosdaq": 1078.5,
+                                                "fearGreed": 33,
+                                                "fearGreedStatus": "FEAR",
+                                                "updatedAt": "2026-02-06T15:03:27"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
+
+
 
     @GetMapping("/index")
     public ApiResponse<MarketIndexResDTO> getMarketIndex() {
@@ -24,6 +69,43 @@ public class MarketController {
                 SuccessCode.OK
         );
     }
+
+    @Operation(
+            summary = "실시간 시장 인사이트 조회",
+            description = """
+                    특정 종목을 중심으로 한 실시간 시장 인사이트를 조회합니다.
+                    
+                    - 현재 시장 참여자의 감정 상태
+                    - 매수/매도 우세 비율
+                    - 신뢰도 레벨
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "실시간 시장 인사이트 조회 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            examples = @ExampleObject(
+                                    name = "시장 인사이트 응답 예시",
+                                    value = """
+                                            {
+                                              "isSuccess": true,
+                                              "code": "COMMON200",
+                                              "message": "요청에 성공했습니다.",
+                                              "result": {
+                                                "stockName": "삼성전자",
+                                                "message": "지금 삼성전자 주주들은 욕심이 커진 상태예요",
+                                                "dominantEmotion": "GREED",
+                                                "buySellRatio": "BUY_DOMINANT",
+                                                "confidenceLevel": "LOW"
+                                              }
+                                            }
+                                            """
+                            )
+                    )
+            )
+    })
     // 실시간 인사이트 조회
     @GetMapping("/insight")
     public ApiResponse<MarketInsightResDTO> getInsightMarketIndex() {
@@ -32,6 +114,5 @@ public class MarketController {
                 SuccessCode.OK
         );
     }
-
 
 }

--- a/src/main/java/com/umc/finly/domain/market/dto/res/FearGreedResDTO.java
+++ b/src/main/java/com/umc/finly/domain/market/dto/res/FearGreedResDTO.java
@@ -1,4 +1,4 @@
-package com.umc.finly.domain.market.dto;
+package com.umc.finly.domain.market.dto.res;
 
 import com.umc.finly.domain.market.enums.FearGreedStatus;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/umc/finly/domain/market/dto/res/MarketIndexResDTO.java
+++ b/src/main/java/com/umc/finly/domain/market/dto/res/MarketIndexResDTO.java
@@ -1,4 +1,4 @@
-package com.umc.finly.domain.market.dto;
+package com.umc.finly.domain.market.dto.res;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;

--- a/src/main/java/com/umc/finly/domain/market/dto/res/MarketIndicesDTO.java
+++ b/src/main/java/com/umc/finly/domain/market/dto/res/MarketIndicesDTO.java
@@ -1,4 +1,4 @@
-package com.umc.finly.domain.market.dto;
+package com.umc.finly.domain.market.dto.res;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/umc/finly/domain/market/dto/res/MarketInsightResDTO.java
+++ b/src/main/java/com/umc/finly/domain/market/dto/res/MarketInsightResDTO.java
@@ -1,4 +1,4 @@
-package com.umc.finly.domain.market.dto;
+package com.umc.finly.domain.market.dto.res;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/umc/finly/domain/market/infra/CnnFearGreedIndexProvider.java
+++ b/src/main/java/com/umc/finly/domain/market/infra/CnnFearGreedIndexProvider.java
@@ -2,7 +2,7 @@ package com.umc.finly.domain.market.infra;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umc.finly.domain.market.dto.FearGreedResDTO;
+import com.umc.finly.domain.market.dto.res.FearGreedResDTO;
 import com.umc.finly.domain.market.enums.FearGreedStatus;
 import com.umc.finly.domain.market.exception.code.MarketErrorCode;
 import com.umc.finly.global.apiPayload.exception.CustomException;

--- a/src/main/java/com/umc/finly/domain/market/infra/FearGreedIndexProvider.java
+++ b/src/main/java/com/umc/finly/domain/market/infra/FearGreedIndexProvider.java
@@ -1,6 +1,6 @@
 package com.umc.finly.domain.market.infra;
 
-import com.umc.finly.domain.market.dto.FearGreedResDTO;
+import com.umc.finly.domain.market.dto.res.FearGreedResDTO;
 
 public interface FearGreedIndexProvider {
     FearGreedResDTO getFearGreedIndex();

--- a/src/main/java/com/umc/finly/domain/market/infra/MarketIndexProvider.java
+++ b/src/main/java/com/umc/finly/domain/market/infra/MarketIndexProvider.java
@@ -1,6 +1,6 @@
 package com.umc.finly.domain.market.infra;
 
-import com.umc.finly.domain.market.dto.MarketIndicesDTO;
+import com.umc.finly.domain.market.dto.res.MarketIndicesDTO;
 
 public interface MarketIndexProvider {
     MarketIndicesDTO getMarketIndices();

--- a/src/main/java/com/umc/finly/domain/market/infra/NaverMarketIndexProvider.java
+++ b/src/main/java/com/umc/finly/domain/market/infra/NaverMarketIndexProvider.java
@@ -2,7 +2,7 @@ package com.umc.finly.domain.market.infra;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umc.finly.domain.market.dto.MarketIndicesDTO;
+import com.umc.finly.domain.market.dto.res.MarketIndicesDTO;
 import com.umc.finly.domain.market.exception.code.MarketErrorCode;
 import com.umc.finly.global.apiPayload.exception.CustomException;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/src/main/java/com/umc/finly/domain/market/service/MarketCacheService.java
+++ b/src/main/java/com/umc/finly/domain/market/service/MarketCacheService.java
@@ -1,4 +1,0 @@
-package com.umc.finly.domain.market.service;
-
-public class MarketCacheService {
-}

--- a/src/main/java/com/umc/finly/domain/market/service/MarketCrawlingService.java
+++ b/src/main/java/com/umc/finly/domain/market/service/MarketCrawlingService.java
@@ -1,4 +1,0 @@
-package com.umc.finly.domain.market.service;
-
-public class MarketCrawlingService {
-}

--- a/src/main/java/com/umc/finly/domain/market/service/MarketIndexService.java
+++ b/src/main/java/com/umc/finly/domain/market/service/MarketIndexService.java
@@ -1,8 +1,8 @@
 package com.umc.finly.domain.market.service;
 
-import com.umc.finly.domain.market.dto.FearGreedResDTO;
-import com.umc.finly.domain.market.dto.MarketIndexResDTO;
-import com.umc.finly.domain.market.dto.MarketIndicesDTO;
+import com.umc.finly.domain.market.dto.res.FearGreedResDTO;
+import com.umc.finly.domain.market.dto.res.MarketIndexResDTO;
+import com.umc.finly.domain.market.dto.res.MarketIndicesDTO;
 import com.umc.finly.domain.market.infra.FearGreedIndexProvider;
 import com.umc.finly.domain.market.infra.MarketIndexProvider;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/umc/finly/domain/market/service/MarketInsightService.java
+++ b/src/main/java/com/umc/finly/domain/market/service/MarketInsightService.java
@@ -1,6 +1,6 @@
 package com.umc.finly.domain.market.service;
 
-import com.umc.finly.domain.market.dto.MarketInsightResDTO;
+import com.umc.finly.domain.market.dto.res.MarketInsightResDTO;
 import com.umc.finly.domain.market.repository.MarketInsightRepository;
 import com.umc.finly.domain.market.repository.projection.StockEmotionBuyAggregation;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #110 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 종목별 감정 분포 그래프 조회 API 구현
- 회원의 기록을 감정 타입(emotionCode) 기준으로 그룹핑하여 집계
- 감정별 비율(percent)을 정수로 계산하고, 합이 100이 되도록 보정 로직 적용
- 기록이 0건인 경우 모든 감정을 0%로 응답하도록 처리

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
- 기록이 홀수일 때 
** EmotionCode 순서에 따라서 count 보정 **
<img width="1196" height="371" alt="image" src="https://github.com/user-attachments/assets/7f793715-608d-4f57-a14c-677b993688ff" />
<img width="1201" height="748" alt="image" src="https://github.com/user-attachments/assets/9a26bcad-34dc-4107-8550-f994fd0af007" />

- 기록이 짝수일 때
<img width="1197" height="397" alt="image" src="https://github.com/user-attachments/assets/e00bef50-43e0-4db2-a0d4-4240eb5c20fb" />
<img width="1180" height="675" alt="image" src="https://github.com/user-attachments/assets/4561166b-ab7f-4296-a93c-e07b36b4bc98" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

- 감정 비율(percent)은 소수점을 사용하지 않고 정수로 응답
- 감정 enum 선언 순서에 따라 count가 동일한 경우 퍼센트 보정 우선순위가 결정
- 감정 분포 그래프는 5개 감정(CALM, ANXIETY, REGRET, GREED, CONFIDENCE)을 기준

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 특정 주식에 대한 감정 분포 조회 기능 추가(감정 유형별 집계 및 비율 제공).
  * 인증된 사용자가 주식별 감정 분포를 조회하는 신규 REST API 추가.
  * 사용자의 기록된 종목 목록을 조회하는 신규 엔드포인트 추가.

* **Documentation**
  * 마켓 및 감정 API에 대한 OpenAPI/응답 예시 문서화 추가.

* **Chores**
  * 마켓 API 경로를 /api/markets로 변경.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->