### PR TITLE
[Feat] 비밀번호 변경 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
@@ -15,6 +15,7 @@ public enum AuthErrorCode implements BaseCode {
     INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "AUTH400_2", "닉네임 형식이 올바르지 않습니다."),
     INVALID_TERM_REQUEST(HttpStatus.BAD_REQUEST, "AUTH400_3", "약관 동의 요청이 올바르지 않습니다."),
     INVALID_PERSONA_ANSWERS(HttpStatus.BAD_REQUEST, "AUTH400_4", "페르소나 답변이 올바르지 않습니다."),
+    INVALID_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH400_5", "비밀번호 확인이 일치하지 않습니다."),
 
     // 401
     INVALID_LOGIN_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH401_1", "이메일 또는 비밀번호가 올바르지 않습니다."),

--- a/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/auth/exception/AuthErrorCode.java
@@ -15,7 +15,7 @@ public enum AuthErrorCode implements BaseCode {
     INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "AUTH400_2", "닉네임 형식이 올바르지 않습니다."),
     INVALID_TERM_REQUEST(HttpStatus.BAD_REQUEST, "AUTH400_3", "약관 동의 요청이 올바르지 않습니다."),
     INVALID_PERSONA_ANSWERS(HttpStatus.BAD_REQUEST, "AUTH400_4", "페르소나 답변이 올바르지 않습니다."),
-    INVALID_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH400_5", "비밀번호 확인이 일치하지 않습니다."),
+    PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH400_5", "비밀번호 확인이 일치하지 않습니다."),
 
     // 401
     INVALID_LOGIN_PASSWORD(HttpStatus.UNAUTHORIZED, "AUTH401_1", "이메일 또는 비밀번호가 올바르지 않습니다."),

--- a/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/auth/service/AuthServiceImpl.java
@@ -20,6 +20,7 @@ import com.umc.finly.domain.member.service.PersonaScoringService;
 import com.umc.finly.global.apiPayload.exception.CustomException;
 import com.umc.finly.global.infra.jwt.JwtProvider;
 import com.umc.finly.global.util.CookieUtil;
+import com.umc.finly.global.util.PasswordPolicy;
 import com.umc.finly.global.util.SecurityUtil;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -51,8 +52,6 @@ public class AuthServiceImpl implements AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
 
-    // 비밀번호 양식
-    private static final String PASSWORD_REGEX = "^(?=.*[A-Za-z])(?=.*\\d).{6,}$";
     // 닉네임 양식
     private static final String NICKNAME_REGEX = "^[가-힣a-zA-Z0-9]{2,}$";
 
@@ -249,7 +248,7 @@ public class AuthServiceImpl implements AuthService {
 
     // -----------------------------------------------------------
     private boolean isValidPassword(String raw) {
-        return raw != null && raw.matches(PASSWORD_REGEX);
+        return PasswordPolicy.isValid(raw);
     }
 
     private boolean isValidNickname(String nickname) {

--- a/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
@@ -1,6 +1,7 @@
 package com.umc.finly.domain.member.controller;
 
 import com.umc.finly.domain.auth.exception.AuthErrorCode;
+import com.umc.finly.domain.member.dto.request.PasswordChangeReqDTO;
 import com.umc.finly.domain.member.dto.request.UpdateNicknameReqDTO;
 import com.umc.finly.domain.member.dto.response.MyPageMeResDTO;
 import com.umc.finly.domain.member.dto.response.MyPagePersonaResDTO;
@@ -10,6 +11,7 @@ import com.umc.finly.global.apiPayload.exception.CustomException;
 import com.umc.finly.global.apiPayload.response.ApiResponse;
 import com.umc.finly.global.apiPayload.response.SuccessCode;
 import com.umc.finly.global.config.security.AuthPrincipal;
+import com.umc.finly.global.util.SecurityUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -109,5 +111,28 @@ public class MyPageController {
                 ),
                 SuccessCode.OK
         );
+    }
+
+    @Operation(
+            summary = "비밀번호 변경",
+            description = """
+                로그인한 사용자의 비밀번호를 변경합니다.
+                
+                - Authorization: Bearer {accessToken} 필요
+                - newPassword와 newPasswordConfirm이 일치해야 합니다.
+                - 비밀번호 정책을 만족해야 합니다.
+                """
+    )
+    @PatchMapping("/me/password")
+    public ApiResponse<Object> changePassword(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @Valid @RequestBody PasswordChangeReqDTO request
+    ){
+        if (principal == null){
+            throw new CustomException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        myPageService.changePassword(principal.getMemberId(), request.getNewPassword(), request.getNewPasswordConfirm());
+        return ApiResponse.onSuccess(new Object(), SuccessCode.OK);
     }
 }

--- a/src/main/java/com/umc/finly/domain/member/dto/request/PasswordChangeReqDTO.java
+++ b/src/main/java/com/umc/finly/domain/member/dto/request/PasswordChangeReqDTO.java
@@ -1,0 +1,20 @@
+package com.umc.finly.domain.member.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PasswordChangeReqDTO {
+
+    @NotBlank(message = "새 비밀번호는 필수입니다.")
+    private String newPassword;
+
+    @NotBlank(message = "새 비밀번호 확인은 필수입니다.")
+    private String newPasswordConfirm;
+}

--- a/src/main/java/com/umc/finly/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/finly/domain/member/entity/Member.java
@@ -63,5 +63,6 @@ public class Member extends CreatedDeletedBaseEntity {
     public void changeNickname(String nickname) {
         this.nickname = nickname;
     }
+    public void changePassword(String encodedPassword) { this.password = encodedPassword; }
 }
 

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageService.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageService.java
@@ -11,4 +11,6 @@ public interface MyPageService {
     MyPageMeResDTO getMyInfo(Long memberId);
     // 내 닉네임 변경
     UpdateNicknameResDTO updateMyNickname(Long memberId, String nickname);
+    // 내 비밀번호 변경
+    void changePassword(Long memberId, String newPassword, String newPasswordConfirm);
 }

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
@@ -1,5 +1,6 @@
 package com.umc.finly.domain.member.service;
 
+import com.umc.finly.domain.auth.exception.AuthErrorCode;
 import com.umc.finly.domain.member.dto.response.MyPageMeResDTO;
 import com.umc.finly.domain.member.dto.response.MyPagePersonaResDTO;
 import com.umc.finly.domain.member.dto.response.UpdateNicknameResDTO;
@@ -8,7 +9,9 @@ import com.umc.finly.domain.member.exception.MemberErrorCode;
 import com.umc.finly.domain.member.repository.MemberPersonaResultRepository;
 import com.umc.finly.domain.member.repository.MemberRepository;
 import com.umc.finly.global.apiPayload.exception.CustomException;
+import com.umc.finly.global.util.PasswordPolicy;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,6 +23,7 @@ public class MyPageServiceImpl implements MyPageService{
 
     private final MemberPersonaResultRepository memberPersonaResultRepository;
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
     // 내 페르소나 조회
     @Override
@@ -53,5 +57,29 @@ public class MyPageServiceImpl implements MyPageService{
         member.changeNickname(nickname);
 
         return UpdateNicknameResDTO.of(member.getNickname());
+    }
+
+    // 내 비밀번호 변경
+    @Override
+    @Transactional
+    public void changePassword(Long memberId, String newPassword, String newPasswordConfirm){
+
+        // 1) confirm 검증
+        if (newPassword == null || newPasswordConfirm == null || !newPassword.equals(newPasswordConfirm)){
+            throw new CustomException(AuthErrorCode.PASSWORD_CONFIRM_MISMATCH);
+        }
+
+        // 2) 정책 검증
+        if (!PasswordPolicy.isValid(newPassword)){
+            throw new CustomException(AuthErrorCode.INVALID_PASSWORD);
+        }
+
+        // 3) Member 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()->new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 4) 저장
+        member.changePassword(passwordEncoder.encode(newPassword));
+        memberRepository.save(member);
     }
 }

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
@@ -65,7 +65,7 @@ public class MyPageServiceImpl implements MyPageService{
     public void changePassword(Long memberId, String newPassword, String newPasswordConfirm){
 
         // 1) confirm 검증
-        if (newPassword == null || newPasswordConfirm == null || !newPassword.equals(newPasswordConfirm)){
+        if (newPassword == null || !newPassword.equals(newPasswordConfirm)){
             throw new CustomException(AuthErrorCode.PASSWORD_CONFIRM_MISMATCH);
         }
 

--- a/src/main/java/com/umc/finly/global/util/PasswordPolicy.java
+++ b/src/main/java/com/umc/finly/global/util/PasswordPolicy.java
@@ -1,4 +1,12 @@
 package com.umc.finly.global.util;
 
-public class PasswordPolicy {
+public final class PasswordPolicy {
+    private PasswordPolicy(){}
+
+    // 비밀번호 정책: 영문 1개 이상 + 숫자 1개 이상 + 6자 이상
+    public static final String REGEX = "^(?=.*[A-Za-z])(?=.*\\d).{6,}$";
+
+    public static boolean isValid(String raw) {
+        return raw != null && raw.matches(REGEX);
+    }
 }

--- a/src/main/java/com/umc/finly/global/util/PasswordPolicy.java
+++ b/src/main/java/com/umc/finly/global/util/PasswordPolicy.java
@@ -1,0 +1,4 @@
+package com.umc.finly.global.util;
+
+public class PasswordPolicy {
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #118 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 비밀번호 정책 검증 util로 분리
- 비밀번호 변경 api 구현 


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
[테스트 결과 보러가기](https://www.notion.so/2ffb7acc900f804db6f3c0e676eb16e4?source=copy_link)


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 마이페이지 비밀번호 변경 기능 추가: 사용자는 마이페이지에서 현재 비밀번호 인증 후 새 비밀번호로 변경할 수 있습니다.
  * 새 비밀번호는 영문자와 숫자 포함, 최소 길이 조건(보안 정책)을 충족해야 하며, 확인 입력과 일치하지 않으면 안내 메시지("비밀번호 확인이 일치하지 않습니다.")가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->