### PR TITLE
[Feat] 감정 분포 그래프 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/analysis/emotion/controller/EmotionAnalysisController.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/controller/EmotionAnalysisController.java
@@ -1,0 +1,42 @@
+package com.umc.finly.domain.analysis.emotion.controller;
+
+import com.umc.finly.domain.analysis.emotion.dto.response.EmotionDistributionResDTO;
+import com.umc.finly.domain.analysis.emotion.service.EmotionAnalysisService;
+import com.umc.finly.global.apiPayload.exception.CustomException;
+import com.umc.finly.global.apiPayload.response.ApiResponse;
+import com.umc.finly.global.apiPayload.response.ErrorCode;
+import com.umc.finly.global.apiPayload.response.SuccessCode;
+import com.umc.finly.global.config.security.AuthPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@Tag(name = "Analysis - emotion", description = "통계 감정 분석 API")
+@RequestMapping("/api/analysis/stocks")
+public class EmotionAnalysisController {
+
+    private final EmotionAnalysisService emotionAnalysisService;
+
+    @Operation(summary = "감정 분포 그래프 API", description = "각 종목의 조각 감정 분포 통계")
+    @GetMapping("/{symbol}/emotion-distribution")
+    public ApiResponse<EmotionDistributionResDTO> getEmotionDistribution(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @PathVariable String symbol
+    ) {
+        if(principal == null){
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        EmotionDistributionResDTO result =
+                emotionAnalysisService.getEmotionDistribution(principal.getMemberId(), symbol);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/converter/EmotionAnalysisConverter.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/converter/EmotionAnalysisConverter.java
@@ -1,0 +1,22 @@
+package com.umc.finly.domain.analysis.emotion.converter;
+
+import com.umc.finly.domain.analysis.emotion.dto.response.EmotionDistributionResDTO;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class EmotionAnalysisConverter {
+
+    // 감정 분포 그래프 응답 DTO 변환
+    public EmotionDistributionResDTO toEmotionDistributionResDTO(
+            long totalCount,
+            EmotionDistributionResDTO.SelectedStock stock,
+            List<EmotionDistributionResDTO.TypeSummary> summaries) {
+        return EmotionDistributionResDTO.builder()
+                .totalCount((int) totalCount)
+                .stock(stock)
+                .typeSummary(summaries)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/dto/response/EmotionDistributionResDTO.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/dto/response/EmotionDistributionResDTO.java
@@ -1,0 +1,38 @@
+package com.umc.finly.domain.analysis.emotion.dto.response;
+
+import com.umc.finly.domain.record.enums.EmotionCode;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmotionDistributionResDTO {
+
+    private int totalCount;                   // 전체 기록 개수
+    private SelectedStock stock;
+    private List<TypeSummary> typeSummary;    // 감정 타입 별 요약 정보 리스트
+
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SelectedStock{
+        private String symbol;
+        private String stockName;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TypeSummary {
+        private EmotionCode type;             // 감정 타입 : ANXIETY, GREED, CALM, CONFIDENCE, REGRET
+        private long count;                   // 해당 감정의 기록 개수
+        private int percent;                  // 전체 대비 비율 (정수, 합 100%)
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/exception/EmotionAnalysisException.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/exception/EmotionAnalysisException.java
@@ -1,0 +1,10 @@
+package com.umc.finly.domain.analysis.emotion.exception;
+
+import com.umc.finly.global.apiPayload.exception.CustomException;
+import com.umc.finly.global.apiPayload.response.BaseCode;
+
+public class EmotionAnalysisException extends CustomException {
+  public EmotionAnalysisException(BaseCode code) {
+    super(code);
+  }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/exception/code/EmotionAnalysisErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/exception/code/EmotionAnalysisErrorCode.java
@@ -1,0 +1,18 @@
+package com.umc.finly.domain.analysis.emotion.exception.code;
+
+import com.umc.finly.global.apiPayload.response.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum EmotionAnalysisErrorCode implements BaseCode {
+
+    // 4xx
+    ANALYSIS_STOCK_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS_EMOTION_404_1", "종목을 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/repository/EmotionAnalysisRepository.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/repository/EmotionAnalysisRepository.java
@@ -1,0 +1,31 @@
+package com.umc.finly.domain.analysis.emotion.repository;
+
+import com.umc.finly.domain.record.entity.RecordEntry;
+import com.umc.finly.domain.record.enums.EmotionCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface EmotionAnalysisRepository extends JpaRepository<RecordEntry, Long> {
+
+    // 회원의 기록을 감정 타입(emotionCode) 기준으로 그룹핑하여 개수 집계
+    @Query("""
+        select r.emotionCode as emotionCode, count(r) as count
+        from RecordEntry r
+        where r.memberId = :memberId
+            and r.stockId = :stockId
+        group by r.emotionCode
+    """)
+    List<EmotionCountProjection> countGroupByEmotionCode(@Param("memberId") Long memberId, @Param("stockId") Long stockId);
+
+
+    // ===== Projection interfaces =====
+
+    // 감정 타입별 개수 조회 결과를 받기 위한 Projection
+    interface EmotionCountProjection {
+        EmotionCode getEmotionCode();
+        Long getCount();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/service/EmotionAnalysisService.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/service/EmotionAnalysisService.java
@@ -1,0 +1,7 @@
+package com.umc.finly.domain.analysis.emotion.service;
+
+import com.umc.finly.domain.analysis.emotion.dto.response.EmotionDistributionResDTO;
+
+public interface EmotionAnalysisService {
+    EmotionDistributionResDTO getEmotionDistribution(Long memberId,String symbol);  // 감정 분포 그래프
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/service/EmotionAnalysisServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/service/EmotionAnalysisServiceImpl.java
@@ -1,0 +1,145 @@
+package com.umc.finly.domain.analysis.emotion.service;
+
+import com.umc.finly.domain.analysis.emotion.converter.EmotionAnalysisConverter;
+import com.umc.finly.domain.analysis.emotion.dto.response.EmotionDistributionResDTO;
+import com.umc.finly.domain.analysis.emotion.exception.code.EmotionAnalysisErrorCode;
+import com.umc.finly.domain.analysis.emotion.repository.EmotionAnalysisRepository;
+import com.umc.finly.domain.market.stock.entity.Stock;
+import com.umc.finly.domain.market.stock.repository.StockRepository;
+import com.umc.finly.domain.record.enums.EmotionCode;
+import com.umc.finly.global.apiPayload.exception.CustomException;
+import com.umc.finly.global.apiPayload.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EmotionAnalysisServiceImpl implements EmotionAnalysisService {
+
+    private final StockRepository stockRepository;
+    private final EmotionAnalysisRepository emotionAnalysisRepository;
+    private final EmotionAnalysisConverter emotionAnalysisConverter;
+
+    @Override
+    public EmotionDistributionResDTO getEmotionDistribution(Long memberId, String symbol) {
+
+        // memberId가 없으면 잘못된 요청으로 처리
+        if (memberId == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // symbol 검증
+        if (symbol == null || symbol.isBlank()) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        // symbol로 Stock을 찾아서 stockId/stockName 확보
+        Stock stock = stockRepository.findBySymbol(symbol)
+                .orElseThrow(() -> new CustomException(EmotionAnalysisErrorCode.ANALYSIS_STOCK_NOT_FOUND));
+
+        // 종목 DTO 생성
+        EmotionDistributionResDTO.SelectedStock stockDto =
+                EmotionDistributionResDTO.SelectedStock.builder()
+                        .symbol(stock.getSymbol())
+                        .stockName(stock.getName())
+                        .build();
+
+        // 감정별 count 집계 조회
+        List<EmotionAnalysisRepository.EmotionCountProjection> projections =
+                emotionAnalysisRepository.countGroupByEmotionCode(memberId, stock.getId());
+
+        // emotionCode -> count 맵으로 변환
+        Map<EmotionCode, Long> countMap = new EnumMap<>(EmotionCode.class);
+        long totalCount = 0;
+
+        for (EmotionAnalysisRepository.EmotionCountProjection p : projections) {
+            // null 방어해서 count 추출
+            long count = (p.getCount() == null) ? 0L : p.getCount();
+
+            // 감정별 count 저장
+            countMap.put(p.getEmotionCode(), count);
+
+            // 전체 개수 누적
+            totalCount += count;
+        }
+
+        // 모든 EmotionCode를 포함하는 summary 리스트 생성(0건도 포함)
+        List<EmotionDistributionResDTO.TypeSummary> summaries = new ArrayList<>();
+
+        for (EmotionCode code : EmotionCode.values()) {
+            // 해당 감정 count 가져오기(없으면 0)
+            long count = countMap.getOrDefault(code, 0L);
+
+            // percent 계산(버림)
+            int percent = 0;
+            if (totalCount > 0) {
+                percent = (int) ((count * 100) / totalCount);
+            }
+
+            // TypeSummary 생성
+            summaries.add(EmotionDistributionResDTO.TypeSummary.builder()
+                    .type(code)
+                    .count(count)
+                    .percent(percent)
+                    .build());
+        }
+
+        // percent 합이 100이 되도록 보정 (분배 방식)
+        adjustPercentTo100(totalCount, summaries);
+
+        // Converter로 최종 응답 조립
+        return emotionAnalysisConverter.toEmotionDistributionResDTO(
+                totalCount,
+                stockDto,
+                summaries
+        );
+    }
+
+    private void adjustPercentTo100(long totalCount, List<EmotionDistributionResDTO.TypeSummary> summaries) {
+        if (totalCount == 0 || summaries == null || summaries.isEmpty()) return;
+
+        int sum = 0;
+        for (var s : summaries) sum += s.getPercent();
+
+        int diff = 100 - sum;
+        if (diff == 0) return;
+
+        // 타깃 선정용 복사 리스트 (원본 순서 보존)
+        List<EmotionDistributionResDTO.TypeSummary> targets = new ArrayList<>(summaries);
+
+        if (diff > 0) {
+            // 부족: count 큰 순(+), 단 0건에 퍼센트 주는 게 싫으면 필터링 가능
+            targets.sort((a, b) -> Long.compare(b.getCount(), a.getCount()));
+
+            for (int i = 0; i < diff; i++) {
+                var t = targets.get(i % targets.size());
+                t.setPercent(t.getPercent() + 1);
+            }
+        } else {
+            // 초과: percent가 0보다 큰 애들에서만 -1 해야 음수 방지
+            int remaining = -diff;
+
+            // (1) count 작은 순으로 먼저 깎기
+            targets.sort((a, b) -> Long.compare(a.getCount(), b.getCount()));
+
+            int idx = 0;
+            int guard = 0; // 무한루프 방지
+            while (remaining > 0 && guard < 10_000) {
+                var t = targets.get(idx % targets.size());
+                if (t.getPercent() > 0) {
+                    t.setPercent(t.getPercent() - 1);
+                    remaining--;
+                }
+                idx++;
+                guard++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #126 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 종목별 감정 분포 그래프 조회 API 구현
- 회원의 기록을 감정 타입(emotionCode) 기준으로 그룹핑하여 집계
- 감정별 비율(percent)을 정수로 계산하고, 합이 100이 되도록 보정 로직 적용
- 기록이 0건인 경우 모든 감정을 0%로 응답하도록 처리


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
- symlbol 오입력 시
<img width="1164" height="1018" alt="image" src="https://github.com/user-attachments/assets/c282ba14-3ab9-48bd-a9b4-1c234410f6aa" />

- 기록이 홀수일 때 
** EmotionCode 순서에 따라서 count 보정 **
<img width="1196" height="371" alt="image" src="https://github.com/user-attachments/assets/7f793715-608d-4f57-a14c-677b993688ff" />
<img width="1201" height="748" alt="image" src="https://github.com/user-attachments/assets/9a26bcad-34dc-4107-8550-f994fd0af007" />

- 기록이 짝수일 때
<img width="1197" height="397" alt="image" src="https://github.com/user-attachments/assets/e00bef50-43e0-4db2-a0d4-4240eb5c20fb" />
<img width="1180" height="675" alt="image" src="https://github.com/user-attachments/assets/4561166b-ab7f-4296-a93c-e07b36b4bc98" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.

- 감정 비율(percent)은 소수점을 사용하지 않고 정수로 응답
- 감정 enum 선언 순서에 따라 count가 동일한 경우 퍼센트 보정 우선순위가 결정
- 감정 분포 그래프는 5개 감정(CALM, ANXIETY, REGRET, GREED, CONFIDENCE)을 기준

## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 주식 종목별 감정 분포 분석 기능 추가 - 특정 주식에 대한 사용자 감정 데이터를 감정 유형별로 분류하여 분포도 제공
  * 인증된 사용자가 종목 심볼을 통해 감정 분석 데이터 조회 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->