### PR TITLE
[Feat] 내 정보 조회 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
@@ -3,10 +3,7 @@ package com.umc.finly.domain.member.controller;
 import com.umc.finly.domain.auth.exception.AuthErrorCode;
 import com.umc.finly.domain.member.dto.request.PasswordChangeReqDTO;
 import com.umc.finly.domain.member.dto.request.UpdateNicknameReqDTO;
-import com.umc.finly.domain.member.dto.response.MyPageMeResDTO;
-import com.umc.finly.domain.member.dto.response.MyPagePersonaResDTO;
-import com.umc.finly.domain.member.dto.response.ProfileImageResDTO;
-import com.umc.finly.domain.member.dto.response.UpdateNicknameResDTO;
+import com.umc.finly.domain.member.dto.response.*;
 import com.umc.finly.domain.member.service.MyPageService;
 import com.umc.finly.global.apiPayload.exception.CustomException;
 import com.umc.finly.global.apiPayload.response.ApiResponse;
@@ -28,6 +25,32 @@ import org.springframework.web.multipart.MultipartFile;
 public class MyPageController {
 
     private final MyPageService myPageService;
+
+    /**
+     * 마이페이지 상단 통합 조회
+     */
+    @Operation(
+            summary = "마이페이지 상단 조회",
+            description = """
+            마이페이지 상단에 필요한 정보를 한 번에 조회합니다.
+            
+            - JWT 인증이 필요한 API입니다.
+            - 닉네임 / 마음지수(finMindIdx) / 조각수(mindPieceCount) / 현재 페르소나(UI용 한글명) 반환
+            """
+    )
+    @GetMapping
+    public ApiResponse<MyPageResDTO> getMyPageTop(
+            @AuthenticationPrincipal AuthPrincipal principal
+    ) {
+        if (principal == null) {
+            throw new CustomException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        return ApiResponse.onSuccess(
+                myPageService.getMyPage(principal.getMemberId()),
+                SuccessCode.OK
+        );
+    }
 
     /**
      * 내 페르소나 조회

--- a/src/main/java/com/umc/finly/domain/member/dto/response/MyPageResDTO.java
+++ b/src/main/java/com/umc/finly/domain/member/dto/response/MyPageResDTO.java
@@ -1,0 +1,34 @@
+package com.umc.finly.domain.member.dto.response;
+
+import com.umc.finly.domain.member.entity.Member;
+import com.umc.finly.domain.member.entity.mapping.MembersPersonasResult;
+import com.umc.finly.domain.member.enums.PersonaUiType;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MyPageResDTO {
+    private Long memberId;
+    private String nickname;
+    private PersonaUiType personaType;
+    private Integer finMindIdx;
+    private Long mindPieceCount;
+
+    public static MyPageResDTO of(
+            Member member,
+            MembersPersonasResult result,
+            long mindPieceCount
+    ){
+        return MyPageResDTO.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .personaType(result.getPersona().getPersonaType().toUiType())
+                .finMindIdx(member.getFinMindIdx())
+                .mindPieceCount(mindPieceCount)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageService.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageService.java
@@ -1,12 +1,11 @@
 package com.umc.finly.domain.member.service;
 
-import com.umc.finly.domain.member.dto.response.MyPageMeResDTO;
-import com.umc.finly.domain.member.dto.response.MyPagePersonaResDTO;
-import com.umc.finly.domain.member.dto.response.ProfileImageResDTO;
-import com.umc.finly.domain.member.dto.response.UpdateNicknameResDTO;
+import com.umc.finly.domain.member.dto.response.*;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface MyPageService {
+    // 마이페이지 조회
+    MyPageResDTO getMyPage(Long memberId);
     // 내 페르소나 조회
     MyPagePersonaResDTO getMyPersona(Long memberId);
     // 내 프로필 정보 조회

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
@@ -1,14 +1,13 @@
 package com.umc.finly.domain.member.service;
 
 import com.umc.finly.domain.auth.exception.AuthErrorCode;
-import com.umc.finly.domain.member.dto.response.MyPageMeResDTO;
-import com.umc.finly.domain.member.dto.response.MyPagePersonaResDTO;
-import com.umc.finly.domain.member.dto.response.ProfileImageResDTO;
-import com.umc.finly.domain.member.dto.response.UpdateNicknameResDTO;
+import com.umc.finly.domain.member.dto.response.*;
 import com.umc.finly.domain.member.entity.Member;
+import com.umc.finly.domain.member.entity.mapping.MembersPersonasResult;
 import com.umc.finly.domain.member.exception.MemberErrorCode;
 import com.umc.finly.domain.member.repository.MemberPersonaResultRepository;
 import com.umc.finly.domain.member.repository.MemberRepository;
+import com.umc.finly.domain.record.repository.FragmentRepository;
 import com.umc.finly.global.apiPayload.exception.CustomException;
 import com.umc.finly.global.infra.image.ImageStorageService;
 import com.umc.finly.global.util.PasswordPolicy;
@@ -26,10 +25,27 @@ public class MyPageServiceImpl implements MyPageService{
 
     private final MemberPersonaResultRepository memberPersonaResultRepository;
     private final MemberRepository memberRepository;
+    private final FragmentRepository fragmentRepository;
 
     private final ImageStorageService imageStorageService;
     private final PasswordEncoder passwordEncoder;
 
+    // 마이페이지 조회
+    @Override
+    public MyPageResDTO getMyPage(Long memberId){
+        // 1) Member 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()-> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 2) 페르소나 결과 조회
+        MembersPersonasResult result = memberPersonaResultRepository.findByMemberIdFetchPersona(memberId)
+                .orElseThrow(() -> new CustomException(MemberErrorCode.PERSONA_RESULT_NOT_FOUND));
+
+        // 3) 조각수 조회
+        long mindPieceCount = fragmentRepository.countByMemberId(memberId);
+
+        return MyPageResDTO.of(member, result, mindPieceCount);
+    }
     // 내 페르소나 조회
     @Override
     public MyPagePersonaResDTO getMyPersona(Long memberId){


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #138 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 내 정보 조회 API 구현 


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
<img width="1170" height="762" alt="image" src="https://github.com/user-attachments/assets/2e621e49-aaac-4868-9c75-a6bd4c5135a8" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.
- 이 테스트 계정에 다른 값이 없어서.. 머지하고 서버에서 한 번 재테스트 해보겠습니다. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 마이페이지 조회 기능 추가: 인증된 사용자가 회원 정보, 성향 유형, 마인드피스 개수 등 자신의 프로필 정보를 통합된 형태로 조회하고 확인할 수 있는 새로운 마이페이지 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->