### PR TITLE
[Feat] 프로필 사진 변경 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
@@ -125,7 +125,7 @@ public class MyPageController {
                 - 이미 프로필 사진이 있는 경우 에러를 반환합니다.
                 """
     )
-    @PostMapping(value = "/profile-image", consumes = "multipart/form-data")
+    @PostMapping(value = "/me/profile-image", consumes = "multipart/form-data")
     public ApiResponse<ProfileImageResDTO> addProfileImage(
             @AuthenticationPrincipal AuthPrincipal principal,
             @RequestPart("image") MultipartFile image
@@ -136,6 +136,31 @@ public class MyPageController {
         return ApiResponse.onSuccess(
                 myPageService.addProfileImage(principal.getMemberId(), image),
                 SuccessCode.CREATED
+        );
+    }
+
+    @Operation(
+            summary = "프로필 사진 변경",
+            description = """
+            사용자의 프로필 이미지를 교체합니다. (없으면 새로 등록)
+            
+            - JWT 인증이 필요한 API입니다.
+            - multipart/form-data 형식으로 이미지를 업로드합니다.
+            - 기존 프로필 이미지가 있으면 새 이미지 저장 후 기존 파일을 삭제합니다.
+            """
+    )
+    @PutMapping(value = "/me/profile-image", consumes = "multipart/form-data")
+    public ApiResponse<ProfileImageResDTO> updateProfileImage(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @RequestPart("image") MultipartFile image
+    ) {
+        if (principal == null) {
+            throw new CustomException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        return ApiResponse.onSuccess(
+                myPageService.updateProfileImage(principal.getMemberId(), image),
+                SuccessCode.OK
         );
     }
 

--- a/src/main/java/com/umc/finly/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/finly/domain/member/entity/Member.java
@@ -50,6 +50,10 @@ public class Member extends CreatedDeletedBaseEntity {
         this.profileImageUrl = imageUrl;
     }
 
+    public void updateProfileImage(String imageUrl) {
+        this.profileImageUrl = imageUrl;
+    }
+
     public boolean hasProfileImage(){
         return this.profileImageUrl != null;
     }

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageService.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageService.java
@@ -15,6 +15,8 @@ public interface MyPageService {
     UpdateNicknameResDTO updateMyNickname(Long memberId, String nickname);
     // 프로필 사진 추가
     ProfileImageResDTO addProfileImage(Long memberId, MultipartFile image);
+    // 프로필 사진 변경
+    ProfileImageResDTO updateProfileImage(Long memberId, MultipartFile image);
     // 내 비밀번호 변경
     void changePassword(Long memberId, String newPassword, String newPasswordConfirm);
 }

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
@@ -92,6 +92,38 @@ public class MyPageServiceImpl implements MyPageService{
                 .build();
     }
 
+    // 프로필 사진 변경
+    @Override
+    @Transactional
+    public ProfileImageResDTO updateProfileImage(Long memberId, MultipartFile image){
+        if (image == null || image.isEmpty()) {
+            throw new CustomException(MemberErrorCode.INVALID_IMAGE_FILE);
+        }
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 이미 프로필 사진이 있는 경우
+        String oldImageUrl = member.getProfileImageUrl();
+
+        // 새 이미지 업로드
+        String newImageUrl = imageStorageService.upload(image, "profile");
+
+        // DB에 새 URL 저장
+        // (member.addProfileImage가 "없을 때만" 동작하는 메서드면, 교체용 setter/update 메서드가 필요)
+        member.updateProfileImage(newImageUrl);
+        memberRepository.save(member);
+
+        // 기존 파일 삭제 (새 업로드/DB 저장 성공 후)
+        if (oldImageUrl != null && !oldImageUrl.isBlank()) {
+            imageStorageService.delete(oldImageUrl);
+        }
+
+        return ProfileImageResDTO.builder()
+                .profileImageUrl(newImageUrl)
+                .build();
+    }
+
     // 내 비밀번호 변경
     @Override
     @Transactional


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #140 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 프로필 사진 변경 api 구현 


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

### 프로필 사진 전제조건 확인
- 프로필 사진 변경 같은 경우, 기존에 이미 프로필 사진이 있어야 함
<img width="1146" height="576" alt="image" src="https://github.com/user-attachments/assets/1b52ca38-044b-47b5-b0da-b59f34414eef" />

### 프로필 사진 변경 
<img width="738" height="314" alt="image" src="https://github.com/user-attachments/assets/a5dd6503-7633-48f2-991b-c777b08a2045" />

### 로컬 파일에 기존 사진 삭제 되었는 지 확인
- 똑같은 사진이 두 개 있는 이유는 테스트 계정 2개 써서 그런거고.. 
- 기존에 있던 ERD 사진이 삭제되고 새로 업로드한 사진으로 새로 생성되었습니다.
<img width="626" height="426" alt="image" src="https://github.com/user-attachments/assets/517d6352-7bed-4a7c-8e3e-c9f8f58a5e8e" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.
- 프로필사진 쪽 엔드포인트 /mypage/profile-image -> /mypage/me/profile-image 로 수정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 프로필 이미지 업데이트 기능 추가: 기존 프로필 사진을 새로운 이미지로 변경할 수 있습니다.
  * 프로필 이미지 변경 시 이전 이미지는 자동으로 삭제됩니다.
  * 인증이 필요한 작업으로 사용자 계정 보안이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->