### PR TITLE
[Feat] 감정 골든 타임 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/analysis/emotion/controller/EmotionAnalysisController.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/controller/EmotionAnalysisController.java
@@ -1,6 +1,7 @@
 package com.umc.finly.domain.analysis.emotion.controller;
 
 import com.umc.finly.domain.analysis.emotion.dto.response.EmotionDistributionResDTO;
+import com.umc.finly.domain.analysis.emotion.dto.response.GoldenTimeResDTO;
 import com.umc.finly.domain.analysis.emotion.dto.response.ShakenKeywordsResDTO;
 import com.umc.finly.domain.analysis.emotion.service.EmotionAnalysisService;
 import com.umc.finly.global.apiPayload.exception.CustomException;
@@ -25,7 +26,7 @@ public class EmotionAnalysisController {
 
     private final EmotionAnalysisService emotionAnalysisService;
 
-    @Operation(summary = "감정 분포 그래프 API", description = "각 종목의 조각 감정 분포 통계")
+    @Operation(summary = "감정 분포 그래프", description = "각 종목의 조각 감정 분포 통계")
     @GetMapping("/{symbol}/emotion-distribution")
     public ApiResponse<EmotionDistributionResDTO> getEmotionDistribution(
             @AuthenticationPrincipal AuthPrincipal principal,
@@ -41,7 +42,7 @@ public class EmotionAnalysisController {
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }
 
-    @Operation(summary = "나를 흔든 키워드 API", description = "DF 방식의 키워드 추출로 상위 8개 키워드 반환")
+    @Operation(summary = "나를 흔든 키워드", description = "DF 방식의 키워드 추출로 상위 8개 키워드 반환")
     @GetMapping("/{symbol}/shaken-keywords")
     public ApiResponse<ShakenKeywordsResDTO> getShakenKeywords(
             @AuthenticationPrincipal AuthPrincipal principal,
@@ -53,6 +54,22 @@ public class EmotionAnalysisController {
 
         ShakenKeywordsResDTO result =
                 emotionAnalysisService.getShakenKeywords(principal.getMemberId(), symbol);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    @Operation(summary = "감정 골든 타임", description = "세션별 기록 분포와 골든 타임 반환")
+    @GetMapping("/{symbol}/emotion-golden-time")
+    public ApiResponse<GoldenTimeResDTO> getEmotionGoldenTime(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @PathVariable String symbol
+    ) {
+        if (principal == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        GoldenTimeResDTO result =
+                emotionAnalysisService.getEmotionGoldenTime(principal.getMemberId(), symbol);
 
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/converter/EmotionAnalysisConverter.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/converter/EmotionAnalysisConverter.java
@@ -69,7 +69,7 @@ public class EmotionAnalysisConverter {
         GoldenTimeResDTO.Summary summaryDto = GoldenTimeResDTO.Summary.builder()
                 .totalRecords(totalRecords)
                 .goldenTime(goldenTime)
-                .goldenTimeName(goldenTime.getGoldenTimeName())
+                .goldenTimeName(goldenTime != null ? goldenTime.getGoldenTimeName() : null)
                 .build();
 
         return GoldenTimeResDTO.builder()

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/converter/EmotionAnalysisConverter.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/converter/EmotionAnalysisConverter.java
@@ -1,8 +1,10 @@
 package com.umc.finly.domain.analysis.emotion.converter;
 
 import com.umc.finly.domain.analysis.emotion.dto.response.EmotionDistributionResDTO;
+import com.umc.finly.domain.analysis.emotion.dto.response.GoldenTimeResDTO;
 import com.umc.finly.domain.analysis.emotion.dto.response.ShakenKeywordsResDTO;
 import com.umc.finly.domain.market.stock.entity.Stock;
+import com.umc.finly.domain.record.enums.Session;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -47,6 +49,43 @@ public class EmotionAnalysisConverter {
                         .stockName(stock.getName())
                         .build())
                 .keywords(items)
+                .build();
+    }
+
+    // 감정 골든 타임 응답 DTO 변환
+    public GoldenTimeResDTO toGoldenTimeResDTO(
+            Stock stock,
+            int totalRecords,
+            Session goldenTime,
+            List<GoldenTimeResDTO.Sessions> sessions
+    ) {
+        // stock 영역 생성
+        GoldenTimeResDTO.SelectedStock stockDto = GoldenTimeResDTO.SelectedStock.builder()
+                .symbol(stock.getSymbol())
+                .name(stock.getName())
+                .build();
+
+        // summary 영역 생성
+        GoldenTimeResDTO.Summary summaryDto = GoldenTimeResDTO.Summary.builder()
+                .totalRecords(totalRecords)
+                .goldenTime(goldenTime)
+                .goldenTimeName(goldenTime.getGoldenTimeName())
+                .build();
+
+        return GoldenTimeResDTO.builder()
+                .stock(stockDto)
+                .summary(summaryDto)
+                .session(sessions)
+                .build();
+    }
+
+    // 세션 1개 요약 DTO 생성
+    public GoldenTimeResDTO.Sessions toSessionSummary(Session session, int recordCount, int percent) {
+        return GoldenTimeResDTO.Sessions.builder()
+                .session(session)
+                .sessionName(session.getSessionName())
+                .recordCount(recordCount)
+                .percent(percent)
                 .build();
     }
 }

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/dto/response/GoldenTimeResDTO.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/dto/response/GoldenTimeResDTO.java
@@ -1,0 +1,50 @@
+package com.umc.finly.domain.analysis.emotion.dto.response;
+
+import com.umc.finly.domain.record.enums.Session;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoldenTimeResDTO {
+
+    private SelectedStock stock;
+    private Summary summary;
+    private List<Sessions> session;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SelectedStock {
+        private String symbol;
+        private String name;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Summary {
+        private int totalRecords;
+        private Session goldenTime;
+        private String goldenTimeName;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Sessions {
+        private Session session;
+        private String sessionName;
+        private int recordCount;
+        private int percent;
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/repository/EmotionAnalysisRepository.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/repository/EmotionAnalysisRepository.java
@@ -29,6 +29,7 @@ public interface EmotionAnalysisRepository extends JpaRepository<RecordEntry, Lo
     from RecordEntry r
     where r.memberId = :memberId
         and r.stockId = :stockId
+        and r.deletedAt is null
     group by r.session
 """)
     List<SessionCountProjection> countGroupBySession(

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/repository/EmotionAnalysisRepository.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/repository/EmotionAnalysisRepository.java
@@ -2,6 +2,7 @@ package com.umc.finly.domain.analysis.emotion.repository;
 
 import com.umc.finly.domain.record.entity.RecordEntry;
 import com.umc.finly.domain.record.enums.EmotionCode;
+import com.umc.finly.domain.record.enums.Session;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -21,11 +22,31 @@ public interface EmotionAnalysisRepository extends JpaRepository<RecordEntry, Lo
     List<EmotionCountProjection> countGroupByEmotionCode(@Param("memberId") Long memberId, @Param("stockId") Long stockId);
 
     List<RecordEntry> findAllByMemberIdAndStockIdAndDeletedAtIsNull(Long memberId, Long stockId);
+
+    // 회원의 기록을 세션(PRE_MARKET/MORNING/AFTERNOON/POST_MARKET) 기준으로 그룹핑하여 개수 집계
+    @Query("""
+    select r.session as session, count(r) as count
+    from RecordEntry r
+    where r.memberId = :memberId
+        and r.stockId = :stockId
+    group by r.session
+""")
+    List<SessionCountProjection> countGroupBySession(
+            @Param("memberId") Long memberId,
+            @Param("stockId") Long stockId
+    );
+
     // ===== Projection interfaces =====
 
     // 감정 타입별 개수 조회 결과를 받기 위한 Projection
     interface EmotionCountProjection {
         EmotionCode getEmotionCode();
         Long getCount();
+    }
+
+    // 세션별 개수 조회 결과를 받기 위한 Projection
+    interface SessionCountProjection {
+        Session getSession();
+        long getCount();
     }
 }

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/service/EmotionAnalysisService.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/service/EmotionAnalysisService.java
@@ -1,9 +1,11 @@
 package com.umc.finly.domain.analysis.emotion.service;
 
 import com.umc.finly.domain.analysis.emotion.dto.response.EmotionDistributionResDTO;
+import com.umc.finly.domain.analysis.emotion.dto.response.GoldenTimeResDTO;
 import com.umc.finly.domain.analysis.emotion.dto.response.ShakenKeywordsResDTO;
 
 public interface EmotionAnalysisService {
     EmotionDistributionResDTO getEmotionDistribution(Long memberId,String symbol);  // 감정 분포 그래프
     ShakenKeywordsResDTO getShakenKeywords(Long memberId, String symbol); // 나를 흔든 키워드
+    GoldenTimeResDTO getEmotionGoldenTime(Long memberId, String symbol); // 감정 골든 타임 조회
 }

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/service/EmotionAnalysisServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/service/EmotionAnalysisServiceImpl.java
@@ -181,12 +181,12 @@ public class EmotionAnalysisServiceImpl implements EmotionAnalysisService {
         // 세션별 count 맵 (없는 세션은 0으로)
         Map<Session, Integer> countMap = new EnumMap<>(Session.class);
         for (Session s : Session.values()) {
-            // // 기본값 0 세팅
+            //기본값 0 세팅
             countMap.put(s, 0);
         }
 
         for (EmotionAnalysisRepository.SessionCountProjection p : projections) {
-            // // group by 결과 반영
+            // group by 결과 반영
             countMap.put(p.getSession(), (int) p.getCount());
         }
 
@@ -200,8 +200,11 @@ public class EmotionAnalysisServiceImpl implements EmotionAnalysisService {
         Map<Session, Integer> percentMap = new EnumMap<>(Session.class);
         int percentSum = 0;
 
+        // 골든타임 선정 (기록 0이면 null)
+        Session goldenTime = (totalRecords == 0) ? null : pickGoldenTime(countMap);
+
         if (totalRecords == 0) {
-            // // 기록이 없으면 모두 0%
+            // 기록이 없으면 모두 0%
             for (Session s : Session.values()) {
                 percentMap.put(s, 0);
             }
@@ -212,15 +215,10 @@ public class EmotionAnalysisServiceImpl implements EmotionAnalysisService {
                 percentSum += percent;
             }
 
-            // // 합이 100이 되도록 보정(diff를 골든타임에 몰아주기)
+            // 합이 100이 되도록 보정(diff를 골든타임에 몰아주기)
             int diff = 100 - percentSum;
-            Session golden = pickGoldenTime(countMap);
-
-            percentMap.put(golden, percentMap.get(golden) + diff);
+            percentMap.put(goldenTime, percentMap.get(goldenTime) + diff);
         }
-
-        // 골든타임 선정(기록 0이면 null)
-        Session goldenTime = (totalRecords == 0) ? null : pickGoldenTime(countMap);
 
         // sessions 리스트 생성(항상 4개 내려줌)
         List<GoldenTimeResDTO.Sessions> sessions = new ArrayList<>();

--- a/src/main/java/com/umc/finly/domain/analysis/emotion/service/EmotionAnalysisServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/emotion/service/EmotionAnalysisServiceImpl.java
@@ -2,6 +2,7 @@ package com.umc.finly.domain.analysis.emotion.service;
 
 import com.umc.finly.domain.analysis.emotion.converter.EmotionAnalysisConverter;
 import com.umc.finly.domain.analysis.emotion.dto.response.EmotionDistributionResDTO;
+import com.umc.finly.domain.analysis.emotion.dto.response.GoldenTimeResDTO;
 import com.umc.finly.domain.analysis.emotion.dto.response.ShakenKeywordsResDTO;
 import com.umc.finly.domain.analysis.emotion.exception.code.EmotionAnalysisErrorCode;
 import com.umc.finly.domain.analysis.emotion.repository.EmotionAnalysisRepository;
@@ -10,6 +11,7 @@ import com.umc.finly.domain.market.stock.entity.Stock;
 import com.umc.finly.domain.market.stock.repository.StockRepository;
 import com.umc.finly.domain.record.entity.RecordEntry;
 import com.umc.finly.domain.record.enums.EmotionCode;
+import com.umc.finly.domain.record.enums.Session;
 import com.umc.finly.global.apiPayload.exception.CustomException;
 import com.umc.finly.global.apiPayload.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -155,6 +157,90 @@ public class EmotionAnalysisServiceImpl implements EmotionAnalysisService {
         );
     }
 
+    @Override
+    public GoldenTimeResDTO getEmotionGoldenTime(Long memberId, String symbol) {
+
+        // memberId가 없으면 인증 실패
+        if (memberId == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        // symbol 검증
+        if (symbol == null || symbol.isBlank()) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        // 종목 조회
+        Stock stock = stockRepository.findBySymbol(symbol)
+                .orElseThrow(() -> new CustomException(EmotionAnalysisErrorCode.ANALYSIS_STOCK_NOT_FOUND));
+
+        // 세션별 count 집계
+        List<EmotionAnalysisRepository.SessionCountProjection> projections =
+                emotionAnalysisRepository.countGroupBySession(memberId, stock.getId());
+
+        // 세션별 count 맵 (없는 세션은 0으로)
+        Map<Session, Integer> countMap = new EnumMap<>(Session.class);
+        for (Session s : Session.values()) {
+            // // 기본값 0 세팅
+            countMap.put(s, 0);
+        }
+
+        for (EmotionAnalysisRepository.SessionCountProjection p : projections) {
+            // // group by 결과 반영
+            countMap.put(p.getSession(), (int) p.getCount());
+        }
+
+        // totalRecords 계산
+        int totalRecords = 0;
+        for (Session s : Session.values()) {
+            totalRecords += countMap.get(s);
+        }
+
+        // percent 계산(버림)
+        Map<Session, Integer> percentMap = new EnumMap<>(Session.class);
+        int percentSum = 0;
+
+        if (totalRecords == 0) {
+            // // 기록이 없으면 모두 0%
+            for (Session s : Session.values()) {
+                percentMap.put(s, 0);
+            }
+        } else {
+            for (Session s : Session.values()) {
+                int percent = (countMap.get(s) * 100) / totalRecords;
+                percentMap.put(s, percent);
+                percentSum += percent;
+            }
+
+            // // 합이 100이 되도록 보정(diff를 골든타임에 몰아주기)
+            int diff = 100 - percentSum;
+            Session golden = pickGoldenTime(countMap);
+
+            percentMap.put(golden, percentMap.get(golden) + diff);
+        }
+
+        // 골든타임 선정(기록 0이면 null)
+        Session goldenTime = (totalRecords == 0) ? null : pickGoldenTime(countMap);
+
+        // sessions 리스트 생성(항상 4개 내려줌)
+        List<GoldenTimeResDTO.Sessions> sessions = new ArrayList<>();
+        for (Session s : Session.values()) {
+            sessions.add(emotionAnalysisConverter.toSessionSummary(
+                    s,
+                    countMap.get(s),
+                    percentMap.get(s)
+            ));
+        }
+
+        // Converter로 최종 응답 조립
+        return emotionAnalysisConverter.toGoldenTimeResDTO(
+                stock,
+                totalRecords,
+                goldenTime,
+                sessions
+        );
+    }
+
     private void adjustPercentTo100(long totalCount, List<EmotionDistributionResDTO.TypeSummary> summaries) {
         if (totalCount == 0 || summaries == null || summaries.isEmpty()) return;
 
@@ -194,5 +280,28 @@ public class EmotionAnalysisServiceImpl implements EmotionAnalysisService {
                 guard++;
             }
         }
+    }
+
+    private Session pickGoldenTime(Map<Session, Integer> countMap) {
+        // 동률이면 MORNING > AFTERNOON > PRE_MARKET > POST_MARKET 우선
+        Session[] priority = {
+                Session.MORNING,
+                Session.AFTERNOON,
+                Session.PRE_MARKET,
+                Session.POST_MARKET
+        };
+
+        Session best = priority[0];
+        int bestCount = -1;
+
+        for (Session s : priority) {
+            int count = countMap.getOrDefault(s, 0);
+            if (count > bestCount) {
+                bestCount = count;
+                best = s;
+            }
+        }
+
+        return best;
     }
 }

--- a/src/main/java/com/umc/finly/domain/record/enums/Session.java
+++ b/src/main/java/com/umc/finly/domain/record/enums/Session.java
@@ -1,12 +1,17 @@
 package com.umc.finly.domain.record.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 import java.time.LocalTime;
 
+@Getter
+@RequiredArgsConstructor
 public enum Session {
-    PRE_MARKET,   // 00:00 ~ 09:00 (장전 브리핑 - 예측의 시간)
-    MORNING,      // 09:00 ~ 12:00 (오전 - 변동성의 시간)
-    AFTERNOON,    // 12:00 ~ 15:30 (오후 - 이성의 시간)
-    POST_MARKET;  // 15:30 ~ 00:00 (장후 복기 - 정리의 시간)
+    PRE_MARKET("장 전"),   // 00:00 ~ 09:00 (장전 브리핑 - 예측의 시간)
+    MORNING("오전"),      // 09:00 ~ 12:00 (오전 - 변동성의 시간)
+    AFTERNOON("오후"),    // 12:00 ~ 15:30 (오후 - 이성의 시간)
+    POST_MARKET("장 마감");  // 15:30 ~ 00:00 (장후 복기 - 정리의 시간)
 
     private static final LocalTime MARKET_OPEN = LocalTime.of(9, 0);
     private static final LocalTime NOON = LocalTime.of(12, 0);
@@ -22,5 +27,22 @@ public enum Session {
         } else {
             return POST_MARKET;
         }
+    }
+
+    private final String label;
+
+    // 골든타임용
+    public String getGoldenTimeName() {
+        return switch (this) {
+            case PRE_MARKET -> "장 전";
+            case POST_MARKET -> "장 마감";
+            case MORNING -> "오전 장";
+            case AFTERNOON -> "오후 장";
+        };
+    }
+
+    // 세션 분포 그래프용
+    public String getSessionName() {
+        return label;
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #141 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.



## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
<img width="1225" height="563" alt="image" src="https://github.com/user-attachments/assets/21445842-9fe9-458c-9b58-4476ed820c7c" />
<img width="1210" height="222" alt="image" src="https://github.com/user-attachments/assets/c18ef01c-deea-4716-865e-f179fd419374" />

```JSON
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "요청에 성공했습니다.",
  "result": {
    "stock": {
      "symbol": "000020",
      "name": "동화약품"
    },
    "summary": {
      "totalRecords": 12,
      "goldenTime": "MORNING",
      "goldenTimeName": "오전 장"
    },
    "session": [
      {
        "session": "PRE_MARKET",
        "sessionName": "장 전",
        "recordCount": 1,
        "percent": 8
      },
      {
        "session": "MORNING",
        "sessionName": "오전",
        "recordCount": 6,
        "percent": 51
      },
      {
        "session": "AFTERNOON",
        "sessionName": "오후",
        "recordCount": 4,
        "percent": 33
      },
      {
        "session": "POST_MARKET",
        "sessionName": "장 마감",
        "recordCount": 1,
        "percent": 8
      }
    ]
  }
}
```


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 특정 종목에 대해 거래 시간대별 '황금 시간'을 계산해 반환하는 조회 API를 추가했습니다.
  * 장 전·오전·오후·장 마감의 세션별 기록 수와 비율을 함께 제공합니다.
* **기능 개선**
  * 기존 감정 관련 엔드포인트의 표시명이 간결화되어 UI/문서 상 표시가 더 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->