### PR TITLE
[Feat] 프로필 사진 삭제 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
@@ -188,6 +188,32 @@ public class MyPageController {
     }
 
     @Operation(
+            summary = "프로필 사진 삭제",
+            description = """
+            사용자의 프로필 이미지를 삭제합니다.
+            
+            - JWT 인증이 필요한 API입니다.
+            - 프로필 이미지가 있으면 파일 삭제 + DB URL null 처리합니다.
+            - 프로필 이미지가 없어도 성공(멱등) 처리합니다.
+            """
+    )
+    @DeleteMapping("/profile-image")
+    public ApiResponse<Object> deleteProfileImage(
+            @AuthenticationPrincipal AuthPrincipal principal
+    ){
+        if (principal == null) {
+            throw new CustomException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        myPageService.deleteProfileImage(principal.getMemberId());
+
+        return ApiResponse.onSuccess(
+                new Object(),
+                SuccessCode.OK
+        );
+    }
+
+    @Operation(
             summary = "비밀번호 변경",
             description = """
             로그인한 사용자의 비밀번호를 변경합니다.

--- a/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
@@ -197,7 +197,7 @@ public class MyPageController {
             - 프로필 이미지가 없어도 성공(멱등) 처리합니다.
             """
     )
-    @DeleteMapping("/profile-image")
+    @DeleteMapping("/me/profile-image")
     public ApiResponse<Object> deleteProfileImage(
             @AuthenticationPrincipal AuthPrincipal principal
     ){

--- a/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
+++ b/src/main/java/com/umc/finly/domain/member/controller/MyPageController.java
@@ -194,7 +194,7 @@ public class MyPageController {
             
             - JWT 인증이 필요한 API입니다.
             - 프로필 이미지가 있으면 파일 삭제 + DB URL null 처리합니다.
-            - 프로필 이미지가 없어도 성공(멱등) 처리합니다.
+            - 프로필 이미지가 없는 경우 404 에러를 반환합니다.
             """
     )
     @DeleteMapping("/me/profile-image")

--- a/src/main/java/com/umc/finly/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/finly/domain/member/entity/Member.java
@@ -46,14 +46,14 @@ public class Member extends CreatedDeletedBaseEntity {
     @Column(name = "profile_image_url", length = 500)
     private String profileImageUrl;
 
-    /** 마이페이지 - 포르필 사진 관련 메서드 **/
+    /** 마이페이지 - 프로필 사진 관련 메서드 **/
     // 이미지 추가
     public void addProfileImage(String imageUrl){
         this.profileImageUrl = imageUrl;
     }
 
     // 이미지 삭제
-    public void clearProfileTimage() {
+    public void clearProfileImage() {
         this.profileImageUrl = null;
     }
 

--- a/src/main/java/com/umc/finly/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/finly/domain/member/entity/Member.java
@@ -46,14 +46,23 @@ public class Member extends CreatedDeletedBaseEntity {
     @Column(name = "profile_image_url", length = 500)
     private String profileImageUrl;
 
+    /** 마이페이지 - 포르필 사진 관련 메서드 **/
+    // 이미지 추가
     public void addProfileImage(String imageUrl){
         this.profileImageUrl = imageUrl;
     }
 
+    // 이미지 삭제
+    public void clearProfileTimage() {
+        this.profileImageUrl = null;
+    }
+
+    // TODO: 코드 리팩토링 예정
     public void updateProfileImage(String imageUrl) {
         this.profileImageUrl = imageUrl;
     }
 
+    // 프로필 이미지 존재 유무
     public boolean hasProfileImage(){
         return this.profileImageUrl != null;
     }

--- a/src/main/java/com/umc/finly/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/member/exception/MemberErrorCode.java
@@ -19,6 +19,7 @@ public enum MemberErrorCode implements BaseCode {
     // 404
     PERSONA_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_1", "페르소나 결과를 찾을 수 없습니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_2", "멤버를 찾을 수 없습니다."),
+    PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER404_3", "프로필 이미지를 찾을 수 없습니다."),
 
     // 413
     IMAGE_FILE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "MEMBER413", "이미지 파일 용량이 너무 큽니다."),

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageService.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageService.java
@@ -16,6 +16,8 @@ public interface MyPageService {
     ProfileImageResDTO addProfileImage(Long memberId, MultipartFile image);
     // 프로필 사진 변경
     ProfileImageResDTO updateProfileImage(Long memberId, MultipartFile image);
+    // 프로필 사진 삭제
+    void deleteProfileImage(Long memberId);
     // 내 비밀번호 변경
     void changePassword(Long memberId, String newPassword, String newPasswordConfirm);
 }

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
@@ -155,7 +155,7 @@ public class MyPageServiceImpl implements MyPageService{
         String oldImageUrl = member.getProfileImageUrl();
 
         // DB 먼저 지우기
-        member.clearProfileTimage();
+        member.clearProfileImage();
         memberRepository.save(member);
 
         // 파일 삭제

--- a/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/member/service/MyPageServiceImpl.java
@@ -140,6 +140,27 @@ public class MyPageServiceImpl implements MyPageService{
                 .build();
     }
 
+    // 프로필 사진 삭제
+    @Override
+    @Transactional
+    public void deleteProfileImage(Long memberId){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 프로필 이미지가 없는 경우
+        if (!member.hasProfileImage()){
+            throw new CustomException(MemberErrorCode.PROFILE_IMAGE_NOT_FOUND);
+        }
+        // 프로필 이미지 있는 경우
+        String oldImageUrl = member.getProfileImageUrl();
+
+        // DB 먼저 지우기
+        member.clearProfileTimage();
+        memberRepository.save(member);
+
+        // 파일 삭제
+        imageStorageService.delete(oldImageUrl);
+    }
     // 내 비밀번호 변경
     @Override
     @Transactional


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #148 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 마이페이지 프로필 사진 삭제 api 구현


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

### 삭제된 모습 
<img width="530" height="293" alt="image" src="https://github.com/user-attachments/assets/86723967-e31c-4dc7-8f2f-49ee226c963f" />

### 파일 삭제된 모습
<img width="1448" height="492" alt="image" src="https://github.com/user-attachments/assets/37b191e5-6721-4a0c-a873-e7e847df399c" />

<img width="960" height="218" alt="image" src="https://github.com/user-attachments/assets/3174d21f-dbd8-41f7-b630-fafa262a4eb7" />

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 프로필 이미지 삭제 기능이 추가되었습니다. 인증된 사용자는 내 계정 설정에서 자신의 프로필 이미지를 삭제할 수 있습니다.
  * 삭제는 멱등적이며, 이미지가 없거나 찾을 수 없을 경우 명확한 오류(존재하지 않음)가 반환됩니다.
  * 인증되지 않은 요청은 접근이 거부됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->