### PR TITLE
[Feat] 하락장 공포지수, 매수 확신도 결과 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisApiSpecification.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisApiSpecification.java
@@ -1,8 +1,6 @@
 package com.umc.finly.domain.analysis.association.controller;
 
-import com.umc.finly.domain.analysis.association.dto.AnalysisEntryResDTO;
-import com.umc.finly.domain.analysis.association.dto.AnalysisStockResDTO;
-import com.umc.finly.domain.analysis.association.dto.DailyChartResDTO;
+import com.umc.finly.domain.analysis.association.dto.*;
 import com.umc.finly.global.apiPayload.response.ApiResponse;
 import com.umc.finly.global.config.security.AuthPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
@@ -155,4 +153,11 @@ public interface AssociationAnalysisApiSpecification {
             )
     })
     public ApiResponse<DailyChartResDTO> getDailyChart(AuthPrincipal principal, String symbol);
+
+    @Operation(summary = "하락장 공포지수 조회", description = "가장 최근 하락장 공포지수를 조회합니다.")
+    public ApiResponse<FearIndexResDTO> getFearIndex(AuthPrincipal principal);
+
+
+    @Operation(summary = "매수 확신도 조회", description = "가장 최근 매수 확신도를 조회합니다.")
+    public ApiResponse<ConvictionScoreResDTO> getConvictionScore(AuthPrincipal principal);
 }

--- a/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisController.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisController.java
@@ -1,21 +1,16 @@
 package com.umc.finly.domain.analysis.association.controller;
 
-import com.umc.finly.domain.analysis.association.dto.AnalysisEntryResDTO;
-import com.umc.finly.domain.analysis.association.dto.DailyChartResDTO;
-import com.umc.finly.domain.analysis.association.dto.AnalysisStockResDTO;
-import com.umc.finly.domain.analysis.association.service.AnalysisEntryService;
-import com.umc.finly.domain.analysis.association.service.AnalysisStockService;
-import com.umc.finly.domain.analysis.association.service.DailyChartService;
+import com.umc.finly.domain.analysis.association.dto.*;
+import com.umc.finly.domain.analysis.association.service.*;
 import com.umc.finly.global.apiPayload.response.ApiResponse;
 import com.umc.finly.global.apiPayload.response.SuccessCode;
 import com.umc.finly.global.config.security.AuthPrincipal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -26,7 +21,8 @@ public class AssociationAnalysisController implements AssociationAnalysisApiSpec
     private final AnalysisEntryService analysisEntryService;
     private final DailyChartService dailyChartService;
     private final AnalysisStockService analysisStockService;
-
+    private final FearIndexService fearIndexService;
+    private final ConvictionScoreService convictionScoreService;
 
     // 사용자 통계 진입 상태 조회 API
     @GetMapping("/entry")
@@ -61,4 +57,30 @@ public class AssociationAnalysisController implements AssociationAnalysisApiSpec
 
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }
+
+    // 시간별 그래프 조회 API
+    //@GetMapping("/stocks/{symbol}/charts/hourly")
+
+    // 하락장 공포지수 조회 API
+    @GetMapping("/fear-index")
+    public ApiResponse<FearIndexResDTO> getFearIndex(
+            @AuthenticationPrincipal AuthPrincipal principal) {
+
+        FearIndexResDTO result = fearIndexService.getFearIndex(principal.getMemberId());
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    // 매수 확신도 조회 API
+    @GetMapping("/conviction-score")
+    public ApiResponse<ConvictionScoreResDTO> getConvictionScore(
+            @AuthenticationPrincipal AuthPrincipal principal) {
+
+        ConvictionScoreResDTO result = convictionScoreService.getConvictionScore(principal.getMemberId());
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
+    // AI 패턴분석 조회 API
+    //@GetMapping("/association/pattern")
 }

--- a/src/main/java/com/umc/finly/domain/analysis/association/converter/ConvictionScoreConverter.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/converter/ConvictionScoreConverter.java
@@ -1,0 +1,32 @@
+package com.umc.finly.domain.analysis.association.converter;
+
+import com.umc.finly.domain.analysis.association.dto.ConvictionScoreResDTO;
+import com.umc.finly.domain.analysis.association.enums.Status;
+
+public class ConvictionScoreConverter {
+
+    public static ConvictionScoreResDTO toConvictionScoreResDTO(int score) {
+        Status status;
+        String phrase;
+
+        if (score >= 85) {
+            status = Status.HIGH;
+            phrase = "확신 판단 정확도 높음";
+        } else if (score >= 70) {
+            status = Status.GOOD;
+            phrase = "확신 판단 신뢰도 양호";
+        } else if (score >= 50) {
+            status = Status.MID;
+            phrase = "판단 신뢰도 불안정";
+        } else {
+            status = Status.LOW;
+            phrase = "충동적 결정 주의";
+        }
+
+        return ConvictionScoreResDTO.builder()
+                .convictionScore(score)
+                .status(status)
+                .phrase(phrase)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/converter/FearIndexConverter.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/converter/FearIndexConverter.java
@@ -1,0 +1,36 @@
+package com.umc.finly.domain.analysis.association.converter;
+
+import com.umc.finly.domain.analysis.association.enums.ChangeDirection;
+import com.umc.finly.domain.analysis.association.dto.FearIndexResDTO;
+
+public class FearIndexConverter {
+
+    public static FearIndexResDTO toFearIndexResDTO(int currentScore, int previousScore) {
+
+        ChangeDirection direction = determineDirection(currentScore, previousScore);
+        int changeValue = Math.abs(currentScore - previousScore);
+        String phrase = determinePhrase(currentScore);
+
+        return FearIndexResDTO.builder()
+                .fearIndex(currentScore)
+                .changeDirection(direction)
+                .changeValue(changeValue)
+                .phrase(phrase)
+                .build();
+    }
+
+    private static ChangeDirection determineDirection(int current, int previous) {
+        if (current > previous) return ChangeDirection.UP;
+        if (current < previous) return ChangeDirection.DOWN;
+        return ChangeDirection.SAME;
+    }
+
+    private static String determinePhrase(int index) {
+        if (80 <= index && index <= 100) return "패닉 반응 가능성 높음";
+        if (60 <= index && index <= 79) return "평소보다 불안에 예민";
+        if (40 <= index && index <= 59) return "하락장에 감정 반응 증가";
+        if (20 <= index && index <= 39) return "비교적 차분한 반응";
+        if (0 <= index && index <= 19) return "하락장에서도 감정 변화 적음";
+        return "범위 외";
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/dto/ConvictionScoreResDTO.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/dto/ConvictionScoreResDTO.java
@@ -1,0 +1,20 @@
+package com.umc.finly.domain.analysis.association.dto;
+
+import com.umc.finly.domain.analysis.association.enums.ChangeDirection;
+import com.umc.finly.domain.analysis.association.enums.Status;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ConvictionScoreResDTO {
+
+    // 매수 확신도
+    private int convictionScore;
+
+    // 점수 구간별 상태 라벨
+    private Status status;
+
+    // 점수 구간별 노출 문구
+    private String phrase;
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/dto/FearIndexResDTO.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/dto/FearIndexResDTO.java
@@ -1,0 +1,22 @@
+package com.umc.finly.domain.analysis.association.dto;
+
+import com.umc.finly.domain.analysis.association.enums.ChangeDirection;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FearIndexResDTO {
+
+    // 하락장 공포지수
+    private int fearIndex;
+
+    // 사용자의 직전 하락장 공포지수 대비 방향
+    private ChangeDirection changeDirection;
+
+    // 직전 대비 변화량(절댓값)
+    private int changeValue;
+
+    // 하락장 공포지수 구간별 노출 문구
+    private String phrase;
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/dto/KoreaInvestRawResponse.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/dto/KoreaInvestRawResponse.java
@@ -27,6 +27,10 @@ public class KoreaInvestRawResponse {
     @JsonProperty("msg1")
     private String msg1;
 
+    // 응답 상세 (output)
+    @JsonProperty("output")
+    private List<Map<String, Object>> output;
+
     // 응답 상세 (output2)
     @JsonProperty("output2")
     private List<Map<String, Object>> output2;

--- a/src/main/java/com/umc/finly/domain/analysis/association/entity/ConvictionScoreResult.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/entity/ConvictionScoreResult.java
@@ -29,13 +29,16 @@ import java.util.List;
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "member_id", nullable = false)
+//    private Member member;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
 
     // 매수 확신도
-    @Column(name = "conviction_score", nullable = false, precision = 5, scale = 2)
-    private BigDecimal convictionScore;
+    @Column(name = "conviction_score", nullable = false)
+    private int convictionScore;
 
     // 분석 기간
     @Column(name = "start_date", nullable = false)
@@ -57,22 +60,22 @@ import java.util.List;
     @Builder.Default
     private BigDecimal confidenceBuyHitRate = BigDecimal.ZERO;
 
-    /* 탐욕 매수 통계 */
-    // 분석 기간 내 총 탐욕 매수 기록 횟수
-    @Column(name = "total_greed_buy_count")
-    @Builder.Default
-    private Integer totalGreedBuyCount = 0;
-    // 분석 기간 내 탐욕 매수 적중 횟수
-    @Column(name = "total_greed_buy_hit_count")
-    @Builder.Default
-    private Integer totalGreedBuyHitCount = 0;
-    // 탐욕 매수 적중률 (확신 매수 변별력 측정용)
-    @Builder.Default
-    @Column(name = "greed_buy_hit_rate", precision = 5, scale = 2)
-    private BigDecimal greedBuyHitRate = BigDecimal.ZERO;
+//    /* 탐욕 매수 통계 */
+//    // 분석 기간 내 총 탐욕 매수 기록 횟수
+//    @Column(name = "total_greed_buy_count")
+//    @Builder.Default
+//    private Integer totalGreedBuyCount = 0;
+//    // 분석 기간 내 탐욕 매수 적중 횟수
+//    @Column(name = "total_greed_buy_hit_count")
+//    @Builder.Default
+//    private Integer totalGreedBuyHitCount = 0;
+//    // 탐욕 매수 적중률 (확신 매수 변별력 측정용)
+//    @Builder.Default
+//    @Column(name = "greed_buy_hit_rate", precision = 5, scale = 2)
+//    private BigDecimal greedBuyHitRate = BigDecimal.ZERO;
 
-    // 매수 확신도 결과 속 포함된 기록별 상세 내역
-    @Builder.Default
-    @OneToMany(mappedBy = "convictionScoreResult", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<ConvictionScoreDetail> details = new ArrayList<>();
+//    // 매수 확신도 결과 속 포함된 기록별 상세 내역
+//    @Builder.Default
+//    @OneToMany(mappedBy = "convictionScoreResult", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<ConvictionScoreDetail> details = new ArrayList<>();
 }

--- a/src/main/java/com/umc/finly/domain/analysis/association/entity/ConvictionScoreResult.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/entity/ConvictionScoreResult.java
@@ -38,7 +38,7 @@ import java.util.List;
 
     // 매수 확신도
     @Column(name = "conviction_score", nullable = false)
-    private int convictionScore;
+    private Integer convictionScore;
 
     // 분석 기간
     @Column(name = "start_date", nullable = false)

--- a/src/main/java/com/umc/finly/domain/analysis/association/entity/FearIndexResult.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/entity/FearIndexResult.java
@@ -28,13 +28,16 @@ import java.util.List;
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id", nullable = false)
-    private Member member;
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "member_id", nullable = false)
+//    private Member member;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
 
     // 하락장 공포지수
-    @Column(name = "fear_index", nullable = false, precision = 5, scale = 2)
-    private BigDecimal fearIndex;
+    @Column(name = "fear_index", nullable = false)
+    private int fearIndex;
 
     // 분석 기간
     @Column(name = "start_date", nullable = false)
@@ -58,7 +61,7 @@ import java.util.List;
     @Column(name = "average_time_weight")
     private Double averageTimeWeight;
 
-    // 하락장 공포지수 결과 속 포함된 세션별 상세 내역
-    @OneToMany(mappedBy = "fearIndexResult", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<FearIndexDetail> details = new ArrayList<>();
+//    // 하락장 공포지수 결과 속 포함된 세션별 상세 내역
+//    @OneToMany(mappedBy = "fearIndexResult", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<FearIndexDetail> details = new ArrayList<>();
 }

--- a/src/main/java/com/umc/finly/domain/analysis/association/entity/FearIndexResult.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/entity/FearIndexResult.java
@@ -37,7 +37,7 @@ import java.util.List;
 
     // 하락장 공포지수
     @Column(name = "fear_index", nullable = false)
-    private int fearIndex;
+    private Integer fearIndex;
 
     // 분석 기간
     @Column(name = "start_date", nullable = false)

--- a/src/main/java/com/umc/finly/domain/analysis/association/enums/ChangeDirection.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/enums/ChangeDirection.java
@@ -1,0 +1,6 @@
+package com.umc.finly.domain.analysis.association.enums;
+
+// 하락장 공포지수
+public enum ChangeDirection {
+    UP, DOWN, SAME
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/enums/Status.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/enums/Status.java
@@ -1,0 +1,6 @@
+package com.umc.finly.domain.analysis.association.enums;
+
+// 매수 확신도
+public enum Status {
+    LOW, MID, GOOD, HIGH
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/exception/ConvictionScoreErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/exception/ConvictionScoreErrorCode.java
@@ -1,0 +1,18 @@
+package com.umc.finly.domain.analysis.association.exception;
+
+import com.umc.finly.global.apiPayload.response.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ConvictionScoreErrorCode implements BaseCode {
+
+    CONVICTION_SCORE_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS404", "해당 기간의 매수 확신도 분석 결과가 존재하지 않습니다."),
+    INVALID_ANALYSIS_PERIOD(HttpStatus.BAD_REQUEST, "ANALYSIS400", "유효하지 않은 분석 기간입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/exception/ConvictionScoreException.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/exception/ConvictionScoreException.java
@@ -1,0 +1,12 @@
+package com.umc.finly.domain.analysis.association.exception;
+
+import com.umc.finly.global.apiPayload.exception.CustomException;
+
+public class ConvictionScoreException extends CustomException {
+
+    public ConvictionScoreException(ConvictionScoreErrorCode errorCode) {super (errorCode);}
+
+    public ConvictionScoreException(ConvictionScoreErrorCode errorCode, String message) {super (errorCode, message);}
+
+    public ConvictionScoreException(ConvictionScoreErrorCode errorCode, String message, Throwable cause) {super (errorCode, message, cause);}
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/exception/FearIndexErrorCode.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/exception/FearIndexErrorCode.java
@@ -1,0 +1,18 @@
+package com.umc.finly.domain.analysis.association.exception;
+
+import com.umc.finly.global.apiPayload.response.BaseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FearIndexErrorCode implements BaseCode {
+
+    FEAR_INDEX_NOT_FOUND(HttpStatus.NOT_FOUND, "ANALYSIS404", "해당 기간의 하락장 공포지수 분석 결과가 존재하지 않습니다."),
+    INVALID_ANALYSIS_PERIOD(HttpStatus.BAD_REQUEST, "ANALYSIS400", "유효하지 않은 분석 기간입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/exception/FearIndexException.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/exception/FearIndexException.java
@@ -1,0 +1,12 @@
+package com.umc.finly.domain.analysis.association.exception;
+
+import com.umc.finly.global.apiPayload.exception.CustomException;
+
+public class FearIndexException extends CustomException {
+
+    public FearIndexException(FearIndexErrorCode errorCode) {super (errorCode);}
+
+    public FearIndexException(FearIndexErrorCode errorCode, String message) {super (errorCode, message);}
+
+    public FearIndexException(FearIndexErrorCode errorCode, String message, Throwable cause) {super (errorCode, message, cause);}
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/infra/KoreaInvestApiCallerImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/infra/KoreaInvestApiCallerImpl.java
@@ -23,7 +23,7 @@ public class KoreaInvestApiCallerImpl implements DailyChartApiCaller {
 
     private final RestClient koreaInvestRestClient;
 
-    // Daily Chart: 국내주식기간별시세(일/주/월/년)[v1_국내주식-016] -> 일봉 조회
+    // [Daily Chart] 국내주식기간별시세(일/주/월/년)[v1_국내주식-016] -> 일봉 조회
     @Override
     public List<Map<String, Object>> fetchDailyCandles(String symbol, String startDate, String endDate) {
         // API 호출
@@ -48,6 +48,12 @@ public class KoreaInvestApiCallerImpl implements DailyChartApiCaller {
 
         return response.getOutput2();
     }
+
+    // [하락장 공포지수]
+    // fetchIndexByMinute
+
+    // [매수 확신도]
+    // fetchIndexByDate
 
     private void validateResponse(KoreaInvestRawResponse response, String symbol) {
         // response가 null인 경우

--- a/src/main/java/com/umc/finly/domain/analysis/association/infra/MarketDataApiCaller.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/infra/MarketDataApiCaller.java
@@ -1,0 +1,8 @@
+package com.umc.finly.domain.analysis.association.infra;
+
+
+public interface MarketDataApiCaller {
+    // [하락장 공포지수] 국내업종 시간별지수(분)
+
+    // [매수 학신도] 국내업종 일자별 지수
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/repository/ConvictionScoreResultRepository.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/repository/ConvictionScoreResultRepository.java
@@ -1,0 +1,16 @@
+package com.umc.finly.domain.analysis.association.repository;
+
+import com.umc.finly.domain.analysis.association.entity.ConvictionScoreResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface ConvictionScoreResultRepository extends JpaRepository<ConvictionScoreResult, Long> {
+
+    // 특정 사용자의 가장 최신 분석 결과(최신 7일치) 조회
+    Optional<ConvictionScoreResult> findFirstByMemberIdOrderByEndDateDesc(Long memberId);
+
+    // 스케줄러 중복 저장 방지용
+    Optional<ConvictionScoreResult> findByMemberIdAndStartDateAndEndDate(Long memberId, LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/repository/FearIndexResultRepository.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/repository/FearIndexResultRepository.java
@@ -1,0 +1,19 @@
+package com.umc.finly.domain.analysis.association.repository;
+
+import com.umc.finly.domain.analysis.association.entity.FearIndexResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface FearIndexResultRepository extends JpaRepository<FearIndexResult, Long> {
+
+    // 특정 사용자의 가장 최신 분석 결과(최신 7일치) 조회
+    Optional<FearIndexResult> findFirstByMemberIdOrderByEndDateDesc(Long memberId);
+
+    // 변화량 비교용: 현재 결과의 시작일보다 이전에 끝난 가장 최근 결과 조회
+    Optional<FearIndexResult> findFirstByMemberIdAndEndDateBeforeOrderByEndDateDesc(Long memberId, LocalDate startDate);
+
+    // 스케줄러 중복 저장 방지용 (특정 기간 데이터 존재 여부 확인)
+    Optional<FearIndexResult> findByMemberIdAndStartDateAndEndDate(Long memberId, LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/service/AnalysisScheduler.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/service/AnalysisScheduler.java
@@ -1,0 +1,35 @@
+package com.umc.finly.domain.analysis.association.service;
+
+import com.umc.finly.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Component
+@RequiredArgsConstructor
+public class AnalysisScheduler {
+
+//    private final FearIndexService fearIndexService;
+//    private final ConvictionScoreService convictionScoreService;
+//    private final MemberRepository memberRepository;
+//
+//    private static final int PERIOD = 7;
+//
+//    @Scheduled(cron = "0 0 2 * * *") // 매일 새벽 2시
+//    @Transactional
+//    public void runDailyAnalysis() {
+//        LocalDate endDate = LocalDate.now();
+//        LocalDate startDate = endDate.minusDays(PERIOD);
+//
+//        memberRepository.findAll().forEach(member -> {
+//            // 1. 하락장 공포지수 별도 분석
+//            fearIndexService.calculateAndSave(member.getId(), startDate, endDate);
+//
+//            // 2. 매수 확신도 별도 분석
+//            convictionScoreService.calculateAndSave(member.getId(), startDate, endDate);
+//        });
+//    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/service/ConvictionScoreService.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/service/ConvictionScoreService.java
@@ -1,0 +1,12 @@
+package com.umc.finly.domain.analysis.association.service;
+
+import com.umc.finly.domain.analysis.association.dto.ConvictionScoreResDTO;
+
+import java.time.LocalDate;
+
+public interface ConvictionScoreService {
+
+    ConvictionScoreResDTO getConvictionScore(Long memberId);
+
+    void calculateAndSave(Long memberId, LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/service/ConvictionScoreServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/service/ConvictionScoreServiceImpl.java
@@ -1,0 +1,38 @@
+package com.umc.finly.domain.analysis.association.service;
+
+import com.umc.finly.domain.analysis.association.converter.ConvictionScoreConverter;
+import com.umc.finly.domain.analysis.association.dto.ConvictionScoreResDTO;
+import com.umc.finly.domain.analysis.association.entity.ConvictionScoreResult;
+import com.umc.finly.domain.analysis.association.exception.ConvictionScoreErrorCode;
+import com.umc.finly.domain.analysis.association.exception.ConvictionScoreException;
+import com.umc.finly.domain.analysis.association.repository.ConvictionScoreResultRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class ConvictionScoreServiceImpl implements ConvictionScoreService {
+
+    private final ConvictionScoreResultRepository convictionScoreResultRepository;
+
+    @Override
+    @Transactional
+    public void calculateAndSave(Long memberId, LocalDate start, LocalDate end) {
+        // TODO: 1. 분석 기간 내 사용자의 매수 기록 조회
+        // TODO: 2. T+5 주가 비교를 통한 적중 여부 판별 및 ConvictionScoreDetail 저장
+        // TODO: 3. 통계 계산(적중률 등) 및 ConvictionScoreResult 저장
+    }
+
+    @Override
+    public ConvictionScoreResDTO getConvictionScore(Long memberId) {
+        // 가장 최신 매수 확신도 결과 조회
+        ConvictionScoreResult currentResult = convictionScoreResultRepository.findFirstByMemberIdOrderByEndDateDesc(memberId)
+                .orElseThrow(() -> new ConvictionScoreException(ConvictionScoreErrorCode.CONVICTION_SCORE_NOT_FOUND));
+
+        return ConvictionScoreConverter.toConvictionScoreResDTO(currentResult.getConvictionScore());
+    }
+
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/service/FearIndexService.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/service/FearIndexService.java
@@ -1,0 +1,12 @@
+package com.umc.finly.domain.analysis.association.service;
+
+import com.umc.finly.domain.analysis.association.dto.FearIndexResDTO;
+
+import java.time.LocalDate;
+
+public interface FearIndexService {
+
+    FearIndexResDTO getFearIndex(Long memberId);
+
+    void calculateAndSave(Long memberId, LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/service/FearIndexServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/service/FearIndexServiceImpl.java
@@ -1,0 +1,48 @@
+package com.umc.finly.domain.analysis.association.service;
+
+import com.umc.finly.domain.analysis.association.converter.FearIndexConverter;
+import com.umc.finly.domain.analysis.association.dto.FearIndexResDTO;
+import com.umc.finly.domain.analysis.association.entity.FearIndexResult;
+import com.umc.finly.domain.analysis.association.exception.FearIndexErrorCode;
+import com.umc.finly.domain.analysis.association.exception.FearIndexException;
+import com.umc.finly.domain.analysis.association.repository.FearIndexResultRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FearIndexServiceImpl implements FearIndexService {
+
+    private final FearIndexResultRepository fearIndexResultRepository;
+
+    @Override
+    @Transactional
+    public void calculateAndSave(Long memberId, LocalDate startDate, LocalDate endDate) {
+        // TODO: 1. 분석 기간 내 DownSession 조회
+        // TODO: 2. 각 세션별 FearIndexDetail 계산 및 저장
+        // TODO: 3. 최종 점수 산출 및 FearIndexResult 저장
+    }
+
+    @Override
+    public FearIndexResDTO getFearIndex(Long memberId) {
+        // 1. 가장 최근에 저장된 분석 결과 조회
+        FearIndexResult currentResult = fearIndexResultRepository.findFirstByMemberIdOrderByEndDateDesc(memberId)
+                .orElseThrow(() -> new FearIndexException(FearIndexErrorCode.FEAR_INDEX_NOT_FOUND));
+
+        // 2. 해당 결과의 시작일(startDate)을 기준으로 그보다 이전의 마지막 데이터 조회 (변화량 비교용)
+        int prevScore = fearIndexResultRepository.findFirstByMemberIdAndEndDateBeforeOrderByEndDateDesc(
+                        memberId, currentResult.getStartDate())
+                .map(FearIndexResult::getFearIndex)
+                .orElse(currentResult.getFearIndex()); // 이전 기록 없으면 현재와 동일 처리
+
+        // 3. 컨버터를 통해 DTO로 변환하여 반환
+        return FearIndexConverter.toFearIndexResDTO(
+                currentResult.getFearIndex(),
+                prevScore
+        );
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/service/MarketDataScheduler.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/service/MarketDataScheduler.java
@@ -1,0 +1,25 @@
+package com.umc.finly.domain.analysis.association.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Component
+@RequiredArgsConstructor
+public class MarketDataScheduler {
+
+    //@Scheduled(cron = "0 0 1 * * *") // 매일 새벽 1시
+    @Transactional
+    public void collectMinuteChangeRate() {
+        // TODO: 1. 외부 API 호출하여 전일 대비율 (MarketChangeRateHistory) 수집
+        // TODO: 2. 하락 세션(DownSession) 판별 로직 실행 및 저장
+    }
+
+    //@Scheduled(cron = "0 0 1 * * *") // 매일 새벽 1시
+    @Transactional
+    public void collectDailyIndex() {
+        // TODO: 1. 외부 API 호출하여 코스피/코스닥 일별 지수 (MarketIndexHistory) 수집
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #109 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- result 테이블에서 결과 조회
- 스케줄러, ApiCaller 등 일부 파일 TODO / 스켈레톤 코드 작성

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="660" height="376" alt="image" src="https://github.com/user-attachments/assets/d7488051-2a12-4ba1-8b4a-af7489761e4f" />

<img width="680" height="339" alt="image" src="https://github.com/user-attachments/assets/c2be4d0d-6e74-42c1-b788-071b465433d3" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

- 프론트 API 연동을 위해 먼저 result 테이블에서 결과만 조회하는 로직만 구현했습니다.
- 실제 주가 데이터 수집,  계산 및 산출 로직은 API 연동 후 추가하겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공포지수 분석 API 추가: 현재 지수, 전주 대비 변화 및 설명 문구 제공.
  * 매수 확신도 분석 API 추가: 점수, 상태(LOW/MID/GOOD/HIGH) 및 설명 문구 제공.
  * 인증된 사용자는 개인화된 최신 분석 결과를 조회할 수 있습니다.

* **오류/예외 처리**
  * 분석 결과 미존재 시 명확한 오류 응답을 반환합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->