### PR TITLE
[Feat] 시간별 그래프 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisApiSpecification.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisApiSpecification.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Tag(name = "AssociationAnalysis", description = "통계 - 연관분석 관련 API")
@@ -155,9 +156,15 @@ public interface AssociationAnalysisApiSpecification {
     })
     public ApiResponse<DailyChartResDTO> getDailyChart(AuthPrincipal principal, String symbol);
 
+    @Operation(summary = "시간별 그래프 조회", description = """
+    선택한 날짜에 대한 시간별 주가 감정 그래프를 조회합니다.
+    - targetDate 넣지 않을 경우 자동으로 당일 날짜 지정됩니다.
+    - targetDate가 휴장일일 때는 prices가 빈 배열로 반환됩니다.
+    """)
+    public ApiResponse<HourlyChartResDTO> getHourlyChart(AuthPrincipal principal, String symbol, LocalDate targetDate);
+
     @Operation(summary = "하락장 공포지수 조회", description = "가장 최근 하락장 공포지수를 조회합니다.")
     public ApiResponse<FearIndexResDTO> getFearIndex(AuthPrincipal principal);
-
 
     @Operation(summary = "매수 확신도 조회", description = "가장 최근 매수 확신도를 조회합니다.")
     public ApiResponse<ConvictionScoreResDTO> getConvictionScore(AuthPrincipal principal);

--- a/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisController.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/controller/AssociationAnalysisController.java
@@ -20,6 +20,7 @@ public class AssociationAnalysisController implements AssociationAnalysisApiSpec
 
     private final AnalysisEntryService analysisEntryService;
     private final DailyChartService dailyChartService;
+    private final HourlyChartService hourlyChartService;
     private final AnalysisStockService analysisStockService;
     private final FearIndexService fearIndexService;
     private final ConvictionScoreService convictionScoreService;
@@ -60,8 +61,20 @@ public class AssociationAnalysisController implements AssociationAnalysisApiSpec
     }
 
     // 시간별 그래프 조회 API
-    //@GetMapping("/stocks/{symbol}/charts/hourly")
+    @GetMapping("/stocks/{symbol}/charts/hourly")
+    public ApiResponse<HourlyChartResDTO> getHourlyChart(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @PathVariable("symbol") String symbol,
+            @RequestParam(value = "targetDate", required = false)
+            @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate targetDate
+    ) {
+        // 날짜가 없으면 오늘 날짜를 기본값으로 설정
+        LocalDate date = (targetDate != null) ? targetDate : LocalDate.now();
 
+        HourlyChartResDTO result = hourlyChartService.getHourlyChart(principal.getMemberId(), symbol, date);
+
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
     // 하락장 공포지수 조회 API
     @GetMapping("/fear-index")
     public ApiResponse<FearIndexResDTO> getFearIndex(

--- a/src/main/java/com/umc/finly/domain/analysis/association/converter/HourlyChartConverter.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/converter/HourlyChartConverter.java
@@ -1,0 +1,52 @@
+package com.umc.finly.domain.analysis.association.converter;
+
+import com.umc.finly.domain.analysis.association.dto.HourlyChartResDTO;
+import com.umc.finly.domain.market.stock.entity.Stock;
+import com.umc.finly.domain.record.entity.RecordEntry;
+import com.umc.finly.domain.record.entity.RecordFeedback;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class HourlyChartConverter {
+
+    public static HourlyChartResDTO toHourlyChartResDTO(Stock stock, LocalDate targetDate,
+                                                        List<HourlyChartResDTO.PriceData> prices,
+                                                        List<RecordEntry> records,
+                                                        Map<Long, RecordFeedback> feedbackMap) {
+        return HourlyChartResDTO.builder()
+                .stockId(stock.getId())
+                .stockCode(stock.getSymbol())
+                .stockName(stock.getName())
+                .now(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")))
+                .targetDate(targetDate)
+                .prices(prices)
+                .records(records.stream()
+                        .map(r -> toRecordData(r, feedbackMap.get(r.getId()))) // RecordEntry ID로 Map 조회
+                        .toList())
+                .build();
+    }
+
+    private static HourlyChartResDTO.RecordData toRecordData(RecordEntry record, RecordFeedback feedback) {
+        BigDecimal qty = record.getQuantity() != null ? record.getQuantity() : BigDecimal.ZERO;
+        BigDecimal unitPrice = record.getUnitPrice() != null ? record.getUnitPrice() : BigDecimal.ZERO;
+
+        return HourlyChartResDTO.RecordData.builder()
+                .recordId(record.getId())
+                .recordDate(record.getRecordDate())
+                .emotionCode(record.getEmotionCode())
+                .emotionIntensity(record.getEmotionIntensity())
+                .tradeAction(record.getTradeAction())
+                .quantity(qty)
+                .unitPrice(unitPrice)
+                .totalPrice(unitPrice.multiply(qty))
+                .memo(record.getMemo())
+                .finlyTalk(feedback != null ? feedback.getContent() : null)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/dto/HourlyChartResDTO.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/dto/HourlyChartResDTO.java
@@ -1,0 +1,41 @@
+package com.umc.finly.domain.analysis.association.dto;
+
+import com.umc.finly.domain.record.enums.EmotionCode;
+import com.umc.finly.domain.record.enums.TradeAction;
+import lombok.Builder;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record HourlyChartResDTO(
+        Long stockId,
+        String stockCode,
+        String stockName,
+        String now,
+        LocalDate targetDate,
+        List<PriceData> prices,
+        List<RecordData> records
+) {
+
+    public record PriceData(
+            String dateTime, // yyyy-MM-dd HH:mm 형식
+            BigDecimal price
+    ) {}
+
+
+    @Builder
+    public record RecordData(
+            Long recordId,
+            LocalDate recordDate,
+            EmotionCode emotionCode,
+            Integer emotionIntensity,
+            TradeAction tradeAction,
+            BigDecimal quantity,
+            BigDecimal unitPrice,
+            BigDecimal totalPrice,
+            String memo,
+            String finlyTalk // record_feedback.content
+    ) {}
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/infra/HourlyChartApiCaller.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/infra/HourlyChartApiCaller.java
@@ -1,0 +1,17 @@
+package com.umc.finly.domain.analysis.association.infra;
+
+import com.umc.finly.domain.analysis.association.dto.KoreaInvestRawResponse;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+public interface HourlyChartApiCaller {
+//    // 오늘 날짜 1분봉 조회 (당일 분봉)
+//    KoreaInvestRawResponse getTodayHourlyChart(String symbol, String time);
+//
+//    // 과거 특정 날짜 분봉 조회 (일별 분봉)
+//    KoreaInvestRawResponse getPastHourlyChart(String symbol, LocalDate targetDate);
+
+    List<Map<String, Object>> fetchHourlyChart(String symbol, String targetDate);
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/infra/KoreaInvestApiCallerImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/infra/KoreaInvestApiCallerImpl.java
@@ -1,5 +1,6 @@
 package com.umc.finly.domain.analysis.association.infra;
 
+import com.umc.finly.domain.analysis.association.dto.HourlyChartResDTO;
 import com.umc.finly.domain.analysis.association.dto.KoreaInvestRawResponse;
 import com.umc.finly.domain.analysis.association.exception.KoreaInvestErrorCode;
 import com.umc.finly.domain.analysis.association.exception.KoreaInvestException;
@@ -10,8 +11,11 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * 한국투자증권 API 실제 구현체
@@ -19,7 +23,7 @@ import java.util.Map;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class KoreaInvestApiCallerImpl implements DailyChartApiCaller {
+public class KoreaInvestApiCallerImpl implements DailyChartApiCaller, HourlyChartApiCaller {
 
     private final RestClient koreaInvestRestClient;
 
@@ -54,6 +58,60 @@ public class KoreaInvestApiCallerImpl implements DailyChartApiCaller {
 
     // [매수 확신도]
     // fetchIndexByDate
+
+    // [Hourly Chart] 주식일별분봉조회
+    @Override
+    public List<Map<String, Object>> fetchHourlyChart(String symbol, String targetDate) {
+        List<Map<String, Object>> allRawData = new ArrayList<>();
+        String nextTime = "153000"; // 시작 시간 (장 마감 시각)
+        boolean hasNext = true;
+
+        while (hasNext) {
+            String finalNextTime = nextTime;
+            KoreaInvestRawResponse response = koreaInvestRestClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/uapi/domestic-stock/v1/quotations/inquire-time-dailychartprice")
+                            .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                            .queryParam("FID_INPUT_ISCD", symbol)
+                            .queryParam("FID_INPUT_HOUR_1", finalNextTime) // 이전 응답의 마지막 시간
+                            .queryParam("FID_INPUT_DATE_1", targetDate)
+                            .queryParam("FID_PW_DATA_INCU_YN", "N")
+                            .queryParam("FID_FAKE_TICK_INCU_YN", " ")
+                            .build())
+                    .header("tr_id", "FHKST03010230")
+                    .retrieve()
+                    .body(KoreaInvestRawResponse.class);
+
+            validateResponse(response, symbol);
+
+            if (response == null || response.getOutput2() == null || response.getOutput2().isEmpty()) {
+                break;
+            }
+
+            List<Map<String, Object>> currentBatch = response.getOutput2();
+            allRawData.addAll(currentBatch);
+
+            // 마지막 데이터의 시간을 확인
+            Map<String, Object> lastData = currentBatch.get(currentBatch.size() - 1);
+            String lastTime = lastData.get("stck_cntg_hour").toString().replaceAll("\"", "");
+
+            // 9시 데이터까지 도달했거나, 더 이상 과거 데이터가 없으면 중단
+            // 한투 API는 내림차순으로 주므로 lastTime이 nextTime과 같으면 끝난 것
+            if (lastTime.compareTo("090000") <= 0 || lastTime.equals(nextTime)) {
+                hasNext = false;
+            } else {
+                // 마지막 시각의 1분 전부터 다시 조회 (중복 방지)
+                int lastTimeInt = Integer.parseInt(lastTime);
+                nextTime = String.format("%06d", lastTimeInt);
+            }
+        }
+
+        // 중복 제거 및 반환
+        return allRawData.stream()
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
 
     private void validateResponse(KoreaInvestRawResponse response, String symbol) {
         // response가 null인 경우

--- a/src/main/java/com/umc/finly/domain/analysis/association/service/HourlyChartService.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/service/HourlyChartService.java
@@ -1,0 +1,10 @@
+package com.umc.finly.domain.analysis.association.service;
+
+import com.umc.finly.domain.analysis.association.dto.HourlyChartResDTO;
+
+import java.time.LocalDate;
+
+public interface HourlyChartService {
+
+    HourlyChartResDTO getHourlyChart(Long memberId, String symbol, LocalDate targetDate);
+}

--- a/src/main/java/com/umc/finly/domain/analysis/association/service/HourlyChartServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/service/HourlyChartServiceImpl.java
@@ -1,0 +1,104 @@
+package com.umc.finly.domain.analysis.association.service;
+
+import com.umc.finly.domain.analysis.association.converter.HourlyChartConverter;
+import com.umc.finly.domain.analysis.association.dto.HourlyChartResDTO;
+import com.umc.finly.domain.analysis.association.exception.KoreaInvestErrorCode;
+import com.umc.finly.domain.analysis.association.exception.KoreaInvestException;
+import com.umc.finly.domain.analysis.association.infra.HourlyChartApiCaller;
+import com.umc.finly.domain.market.stock.entity.Stock;
+import com.umc.finly.domain.market.stock.repository.StockRepository;
+import com.umc.finly.domain.record.entity.RecordEntry;
+import com.umc.finly.domain.record.entity.RecordFeedback;
+import com.umc.finly.domain.record.repository.RecordEntryRepository;
+import com.umc.finly.domain.record.repository.RecordFeedbackRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HourlyChartServiceImpl implements HourlyChartService {
+
+    private final StockRepository stockRepository;
+    private final RecordEntryRepository recordEntryRepository;
+    private final RecordFeedbackRepository recordFeedbackRepository;
+    private final HourlyChartApiCaller chartApiCaller;
+
+    @Override
+    public HourlyChartResDTO getHourlyChart(Long memberId, String symbol, LocalDate targetDate) {
+        // 1. Symbol로 Stock 엔티티 조회 (stockId를 얻기 위함)
+        Stock stock = stockRepository.findBySymbol(symbol)
+                .orElseThrow(() -> new KoreaInvestException(KoreaInvestErrorCode.STOCK_NOT_FOUND));
+        Long stockId = stock.getId();
+
+        // 2. 주가 데이터 API 호출 및 가공
+        String formattedDate = targetDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        List<Map<String, Object>> rawOutput = chartApiCaller.fetchHourlyChart(symbol, formattedDate);
+
+        List<HourlyChartResDTO.PriceData> prices = new ArrayList<>();
+
+        // 3. 데이터 존재 여부 및 휴장일 체크
+        if (!rawOutput.isEmpty()) {
+            String actualDate = rawOutput.get(0).get("stck_bsop_date").toString().replaceAll("\"", "");
+
+            // 요청 날짜와 API 응답 날짜가 같을 때만 파싱 진행 (다르면 휴장일이므로 prices는 빈 리스트 유지)
+            if (formattedDate.equals(actualDate)) {
+                prices = parsePrices(rawOutput, targetDate);
+            }
+        }
+        // rawOutput이 비어있다면 prices는 빈 리스트가 됨
+
+        // 3. 감정 기록 조회 (추출한 stockId 사용)
+        List<RecordEntry> records = recordEntryRepository.findAllByMemberIdAndStockIdAndRecordDate(memberId, stockId, targetDate);
+        List<Long> recordIds = records.stream().map(RecordEntry::getId).toList();
+
+        // 4. 피드백 조회 및 Map 구성
+        Map<Long, RecordFeedback> feedbackMap = recordFeedbackRepository.findAllByRecordEntryIdInAndMemberId(recordIds, memberId)
+                .stream()
+                .collect(Collectors.toMap(
+                        RecordFeedback::getRecordEntryId,
+                        fb -> fb,
+                        (existing, replacement) -> existing
+                ));
+
+        // 5. Converter를 통해 최종 DTO 생성
+        return HourlyChartConverter.toHourlyChartResDTO(stock, targetDate, prices, records, feedbackMap);
+    }
+
+    private List<HourlyChartResDTO.PriceData> parsePrices(List<Map<String, Object>> rawOutput, LocalDate targetDate) {
+        LocalDate today = LocalDate.now();
+        LocalTime limitTime = LocalTime.now().minusMinutes(1);
+
+        return rawOutput.stream()
+                .map(node -> {
+                    String date = node.get("stck_bsop_date").toString().replaceAll("\"", "");
+                    String rawHour = node.get("stck_cntg_hour").toString().replaceAll("\"", "");
+
+                    // "yyyy-MM-dd HH:mm" 포맷 생성
+                    String formattedDateTime = String.format("%s-%s-%s %s:%s",
+                            date.substring(0, 4), date.substring(4, 6), date.substring(6, 8),
+                            rawHour.substring(0, 2), rawHour.substring(2, 4));
+
+                    BigDecimal price = new BigDecimal(node.get("stck_prpr").toString().replaceAll("\"", ""));
+                    return new HourlyChartResDTO.PriceData(formattedDateTime, price);
+                })
+                .filter(p -> {
+                    LocalTime t = LocalTime.parse(p.dateTime().substring(11));
+                    boolean withinRange = !t.isBefore(LocalTime.of(9, 0)) && !t.isAfter(LocalTime.of(15, 30));
+                    // 오늘이면 현재 시각 1분 전까지만 표시
+                    return targetDate.equals(today) ? withinRange && !t.isAfter(limitTime) : withinRange;
+                })
+                .sorted(Comparator.comparing(HourlyChartResDTO.PriceData::dateTime))
+                .toList();
+    }
+}

--- a/src/main/java/com/umc/finly/domain/record/repository/RecordEntryRepository.java
+++ b/src/main/java/com/umc/finly/domain/record/repository/RecordEntryRepository.java
@@ -53,15 +53,13 @@ public interface RecordEntryRepository extends JpaRepository<RecordEntry, Long> 
         """)
     List<Long> findTopStockByMemberId(@Param("memberId") Long memberId, Pageable pageable);
 
-    /**
-     * recordDate을 기준으로 특정 종목에 대해 특정 기간 내의 모든 기록 조회
-     * @param memberId 회원 PK
-     * @param stockId 종목 PK
-     * @param startDate 조회 시작일
-     * @param endDate 조회 종료일
-     * @return 검색된 기록 리스트
-     */
+
+    // memberId, stockId, recordDate 기간 기준 모든 기록 조회
     List<RecordEntry> findAllByMemberIdAndStockIdAndRecordDateBetween(Long memberId, Long stockId, LocalDate startDate, LocalDate endDate);
 
+    // memberId, recordDate 기간 기준 모든 기록 조회
     List<RecordEntry> findAllByMemberIdAndRecordDateBetween(Long memberId, LocalDate startDate, LocalDate endDate);
+
+    // memberId, stockId, recordDate(하루)를 조건으로 모든 기록 조회
+    List<RecordEntry> findAllByMemberIdAndStockIdAndRecordDate(Long memberId, Long stockId, LocalDate recordDate);
 }

--- a/src/main/java/com/umc/finly/domain/record/repository/RecordFeedbackRepository.java
+++ b/src/main/java/com/umc/finly/domain/record/repository/RecordFeedbackRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 // AI 피드백(RecordFeedback) 엔티티의 데이터 접근 레이어
@@ -24,4 +25,7 @@ public interface RecordFeedbackRepository extends JpaRepository<RecordFeedback, 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT f FROM RecordFeedback f WHERE f.recordEntryId = :recordEntryId")
     Optional<RecordFeedback> findByRecordEntryIdForUpdate(@Param("recordEntryId") Long recordEntryId);
+
+    // recordEntryId 리스트와 memberId로 피드백 리스트 조회
+    List<RecordFeedback> findAllByRecordEntryIdInAndMemberId(List<Long> recordEntryIds, Long memberId);
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #108 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

targetDate 9시~15:30 1분마다 가격 데이터와 targetDate 날짜의 기록 반환

- AnalysisController에 getHourlyChart 추가
- KoreaInvestApiCallerImpl에 fetchHourlyChart 추가 
-  HourlyChartConverter, HourlyChartResDTO, HourlyChartApiCaller, HourlyChartService, HourlyChartServiceImpl


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

- 영업일일 때

<img width="783" height="570" alt="image" src="https://github.com/user-attachments/assets/d237e008-b113-47da-b4eb-fb0ff7f6d3b3" />

<img width="691" height="405" alt="image" src="https://github.com/user-attachments/assets/c951d04e-fb9a-491d-ad66-61cd04ed4df6" />

<img width="700" height="402" alt="image" src="https://github.com/user-attachments/assets/c8f7fba9-bb08-4874-9614-90667c124ec8" />

- 휴장일이거나 장 시작 전일 때
<img width="782" height="406" alt="image" src="https://github.com/user-attachments/assets/edd942ad-4518-4cf0-97bb-b28bd9cf2fec" />

<img width="790" height="425" alt="image" src="https://github.com/user-attachments/assets/de24d6a5-ab07-4ccc-87c5-3a0b968fc07b" />

 

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**새로운 기능**
* 시간별 차트 조회 기능 추가 - 주식의 시간 단위 가격 변동을 확인할 수 있습니다.
* 선택적 날짜 지정 지원 - 특정 날짜를 지정하거나 현재 날짜를 기본값으로 사용할 수 있습니다.
* 거래 기록 및 피드백 통합 - 시간별 가격 데이터와 함께 거래 기록 및 관련 피드백을 함께 조회할 수 있습니다.
* 휴장일 처리 - 휴장일에는 가격 데이터가 비어있게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->