### PR TITLE
[Hotfix] docker-compose.yml 타임존 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     image: finly-backend
     container_name: finly-backend
     environment:
+      TZ: Asia/Seoul
       SPRING_PROFILES_ACTIVE: prod
       SPRING_DATASOURCE_URL: ${DB_URL}
       SPRING_DATASOURCE_USERNAME: ${DB_USERNAME}

--- a/src/main/java/com/umc/finly/domain/analysis/association/infra/KoreaInvestApiCallerImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/infra/KoreaInvestApiCallerImpl.java
@@ -80,9 +80,10 @@ public class KoreaInvestApiCallerImpl implements DailyChartApiCaller, HourlyChar
                             .build())
                     .header("tr_id", "FHKST03010230")
                     .retrieve()
+                    .onStatus(HttpStatusCode::isError, (request, response1) -> {
+                        throw new KoreaInvestException(KoreaInvestErrorCode.API_CALL_ERROR);
+                    })
                     .body(KoreaInvestRawResponse.class);
-
-            validateResponse(response, symbol);
 
             if (response == null || response.getOutput2() == null || response.getOutput2().isEmpty()) {
                 break;


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 도커 컨테이너의 타임존이 UTC로 되어있어 기록 날짜 찾을 때 하루씩 전으로 밀리는 문제 해결을 위해 컴포즈 설정 파일에 타임존 추가


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.
<img width="521" height="41" alt="image" src="https://github.com/user-attachments/assets/2cbc1336-c6f6-433e-8d13-7499edb8da7c" />



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.