### PR TITLE
[Feat] 프로필 조회/프로필 수정 페이지에 프로필 사진 조회 기능 추가

### DIFF
--- a/src/main/java/com/umc/finly/domain/member/dto/response/MyPageMeResDTO.java
+++ b/src/main/java/com/umc/finly/domain/member/dto/response/MyPageMeResDTO.java
@@ -13,12 +13,14 @@ public class MyPageMeResDTO {
     private Long memberId;
     private String email;
     private String nickname;
+    private String profileImageUrl;
 
     public static MyPageMeResDTO from(Member member){
         return MyPageMeResDTO.builder()
                 .memberId(member.getId())
                 .email(member.getEmail())
                 .nickname(member.getNickname())
+                .profileImageUrl(member.getProfileImageUrl())
                 .build();
     }
 }

--- a/src/main/java/com/umc/finly/domain/member/dto/response/MyPageResDTO.java
+++ b/src/main/java/com/umc/finly/domain/member/dto/response/MyPageResDTO.java
@@ -17,6 +17,7 @@ public class MyPageResDTO {
     private PersonaUiType personaType;
     private Integer finMindIdx;
     private Long mindPieceCount;
+    private String profileImageUrl;
 
     public static MyPageResDTO of(
             Member member,
@@ -29,6 +30,7 @@ public class MyPageResDTO {
                 .personaType(result.getPersona().getPersonaType().toUiType())
                 .finMindIdx(member.getFinMindIdx())
                 .mindPieceCount(mindPieceCount)
+                .profileImageUrl(member.getProfileImageUrl())
                 .build();
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #164 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
- 프로필 조회랑 프로필 수정 페이지 조회 시 프로필 이미지 필드가 누락되어 있어 추가했습니다.


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 마이페이지 조회 응답에 프로필 이미지 URL 정보 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->