### PR TITLE
[Refactor] 금융 마음 지수 저장 로직

### DIFF
--- a/src/main/java/com/umc/finly/domain/home/service/HomeMindServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/home/service/HomeMindServiceImpl.java
@@ -14,6 +14,7 @@ import com.umc.finly.domain.record.enums.TradeAction;
 import com.umc.finly.global.apiPayload.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -76,6 +77,8 @@ public class HomeMindServiceImpl implements HomeMindService {
           return result;
       }
 
+      //Home 진입 시 → FMI 계산 → Member에 저장
+    @Transactional
     @Override
     public HomeMindResDTO getHomeMind(Long memberId) {//금융 마음 지수 조회 서비스 로직
 
@@ -86,6 +89,8 @@ public class HomeMindServiceImpl implements HomeMindService {
                 personaRepository.findById(member.getPersonaId()).orElse(null);
 
         MindScoreResult score = calculateMindScores(memberId);
+
+        member.updateFinMindIdx(score.fmi);//
 
         return HomeMindResDTO.builder()
                 .memberName(member.getNickname())

--- a/src/main/java/com/umc/finly/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/finly/domain/member/entity/Member.java
@@ -91,4 +91,9 @@ public class Member extends CreatedDeletedBaseEntity {
         this.nickname = nickname;
     }
     public void changePassword(String encodedPassword) { this.password = encodedPassword; }
+
+    public void updateFinMindIdx(int finMindIdx) {
+        this.finMindIdx = finMindIdx;
+    }//금융 마음 지수 저장
+
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #171 

## 📌 작업 내용
> 
- 금융 마음 지수를 사용자 멤버 엔티티에 저장하여 마이페이지에도 표시되 게 수정했습니다!
- 그 과정에서 멤버 엔티티에 함수를 추가했습니다 참고해주세요!  @na311ng 


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="892" height="329" alt="image" src="https://github.com/user-attachments/assets/74e54183-1894-4eda-b285-983d9bccd4f7" />
<img width="899" height="338" alt="image" src="https://github.com/user-attachments/assets/4720fec1-fb67-48f6-9ee5-fa2f34c7e90f" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 금융 마인드 지수가 계산된 후 사용자 계정에 자동으로 저장되고 반영되도록 개선했습니다. 이제 최신 계산된 지수가 항상 사용자 프로필에 정확하게 기록되어 사용자 정보가 최신 상태로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->