### PR TITLE
[Feat] 캘린더용 날짜별 조각 조회 API

### DIFF
--- a/src/main/java/com/umc/finly/domain/record/controller/FragmentController.java
+++ b/src/main/java/com/umc/finly/domain/record/controller/FragmentController.java
@@ -81,5 +81,4 @@ public class FragmentController {
         FragmentCalendarResDTO result = fragmentService.getFragmentCalendar(principal.getMemberId(), yearMonth);
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }
-
 }

--- a/src/main/java/com/umc/finly/domain/record/controller/FragmentController.java
+++ b/src/main/java/com/umc/finly/domain/record/controller/FragmentController.java
@@ -1,5 +1,6 @@
 package com.umc.finly.domain.record.controller;
 
+import com.umc.finly.domain.record.dto.res.FragmentCalendarResDTO;
 import com.umc.finly.domain.record.dto.res.FragmentSummaryResDTO;
 import com.umc.finly.domain.record.dto.res.FragmentListResDTO;
 import com.umc.finly.domain.record.enums.EmotionCode;
@@ -64,4 +65,21 @@ public class FragmentController {
 
         return ApiResponse.onSuccess(result, SuccessCode.OK);
     }
+
+    // 기록 홈 캘린더용 날짜별 조각 집계 조회
+    // yearMonth(yyyy-MM) 기준으로 해당 월 범위 내 날짜별/감정별 count를 반환
+    @Operation(summary = "캘린더용 날짜별 조각 조회 API", description = "기록 홈 월 캘린더에서 날짜 별 조각 여부/개수를 표시하기 위한 API")
+    @GetMapping("/calendar")
+    public ApiResponse<FragmentCalendarResDTO> getFragmentCalendar(
+            @AuthenticationPrincipal AuthPrincipal principal,
+            @RequestParam(required = false) String yearMonth
+    ) {
+        if (principal == null) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED);
+        }
+
+        FragmentCalendarResDTO result = fragmentService.getFragmentCalendar(principal.getMemberId(), yearMonth);
+        return ApiResponse.onSuccess(result, SuccessCode.OK);
+    }
+
 }

--- a/src/main/java/com/umc/finly/domain/record/converter/FragmentConverter.java
+++ b/src/main/java/com/umc/finly/domain/record/converter/FragmentConverter.java
@@ -1,5 +1,6 @@
 package com.umc.finly.domain.record.converter;
 
+import com.umc.finly.domain.record.dto.res.FragmentCalendarResDTO;
 import com.umc.finly.domain.record.dto.res.FragmentListResDTO;
 import com.umc.finly.domain.record.dto.res.FragmentSummaryResDTO;
 import com.umc.finly.domain.record.enums.EmotionCode;
@@ -65,6 +66,26 @@ public class FragmentConverter {
                 .fragments(rows.stream()
                         .map(this::toFragment)
                         .collect(Collectors.toList()))
+                .build();
+    }
+
+    // 캘린더용 응답 DTO 변환
+    // yearMonth: yyyy-MM / from~to: 해당 월 범위 / days: 날짜별 집계 결과
+    public FragmentCalendarResDTO toCalendarFragment(
+            String yearMonth,
+            LocalDate from,
+            LocalDate to,
+            long totalRecords,
+            List<FragmentCalendarResDTO.Day> days
+    ){
+        return FragmentCalendarResDTO.builder()
+                .yearMonth(yearMonth)
+                .range(FragmentCalendarResDTO.Range.builder()
+                        .from(from)
+                        .to(to)
+                        .build())
+                .totalRecords(totalRecords)
+                .days(days)
                 .build();
     }
 

--- a/src/main/java/com/umc/finly/domain/record/dto/res/FragmentCalendarResDTO.java
+++ b/src/main/java/com/umc/finly/domain/record/dto/res/FragmentCalendarResDTO.java
@@ -1,0 +1,50 @@
+package com.umc.finly.domain.record.dto.res;
+
+import com.umc.finly.domain.record.enums.EmotionCode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FragmentCalendarResDTO {
+
+    private String yearMonth;            // 조회 년월 (yyyy-mm)
+    private Range range;                 // 조회 범위
+    private long totalRecords;           // 기록이 존재하는 날짜 리스트
+    private List<Day> days;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Range{
+        private LocalDate from;
+        private LocalDate to;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Day{
+        private LocalDate date;
+        private long totalCount;
+        private List<TypeCount> byType;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TypeCount{
+        private EmotionCode type;
+        private long count;
+    }
+}

--- a/src/main/java/com/umc/finly/domain/record/dto/res/FragmentCalendarResDTO.java
+++ b/src/main/java/com/umc/finly/domain/record/dto/res/FragmentCalendarResDTO.java
@@ -17,16 +17,16 @@ public class FragmentCalendarResDTO {
 
     private String yearMonth;            // 조회 년월 (yyyy-mm)
     private Range range;                 // 조회 범위
-    private long totalRecords;           // 기록이 존재하는 날짜 리스트
-    private List<Day> days;
+    private long totalRecords;           // 조회 범위 내 전체 기록 수
+    private List<Day> days;              // 기록이 존재하는 날짜 리스트
 
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Range{
-        private LocalDate from;
-        private LocalDate to;
+        private LocalDate from;          // 시작 날짜
+        private LocalDate to;            // 종료 날짜
     }
 
     @Getter
@@ -34,9 +34,9 @@ public class FragmentCalendarResDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Day{
-        private LocalDate date;
-        private long totalCount;
-        private List<TypeCount> byType;
+        private LocalDate date;          // 기록 날짜
+        private long totalCount;         // 해당 날짜의 총 기록 갯수
+        private List<TypeCount> byType;  // 감정별 기록 수
     }
 
     @Getter
@@ -44,7 +44,7 @@ public class FragmentCalendarResDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class TypeCount{
-        private EmotionCode type;
-        private long count;
+        private EmotionCode type;        // 감정 타입
+        private long count;              // 해당 감정 기록 수
     }
 }

--- a/src/main/java/com/umc/finly/domain/record/repository/FragmentRepository.java
+++ b/src/main/java/com/umc/finly/domain/record/repository/FragmentRepository.java
@@ -72,6 +72,39 @@ public interface FragmentRepository extends JpaRepository<RecordEntry, Long> {
             @Param("toDate") LocalDate toDate
     );
 
+    // 캘린더용 날짜별/감정별 조각 개수 집계
+    // 특정 기간(from~to) 내 recordDate + emotionCode 기준으로 그룹핑하여 count를 반환
+    @Query("""
+    select r.recordDate as recordDate, r.emotionCode as emotionCode, count(r) as count
+    from RecordEntry r
+    where r.memberId = :memberId
+      and r.recordDate >= :fromDate
+      and r.recordDate <= :toDate
+    group by r.recordDate, r.emotionCode
+    order by r.recordDate asc
+    """)
+    List<CalendarCountProjection> countCalendarByDateAndEmotion(
+            @Param("memberId") Long memberId,
+            @Param("fromDate") LocalDate fromDate,
+            @Param("toDate") LocalDate toDate
+    );
+
+    // 캘린더 범위(from~to) 내 전체 기록 수 조회
+    @Query("""
+    select count(r)
+    from RecordEntry r
+    where r.memberId = :memberId
+      and r.recordDate >= :fromDate
+      and r.recordDate <= :toDate
+      and r.deletedAt is null
+    """)
+    long countByMemberIdAndRecordDateBetween(
+            @Param("memberId") Long memberId,
+            @Param("fromDate") LocalDate fromDate,
+            @Param("toDate") LocalDate toDate
+    );
+
+
     // ===== Projection Interfaces =====
 
     // 감정별 개수 집계 결과를 받기 위한 Projection
@@ -91,5 +124,12 @@ public interface FragmentRepository extends JpaRepository<RecordEntry, Long> {
         BigDecimal getQuantity();     // 수량
         String getMemo();             // 메모
         EmotionCode getEmotionCode(); // 감정 코드
+    }
+
+    // 캘린더 집계 결과를 받기 위한 Projection
+    interface CalendarCountProjection {
+        LocalDate getRecordDate();    // 기록 날짜
+        EmotionCode getEmotionCode(); // 감정 코드
+        Long getCount();              // 해당 날짜/감정의 기록 개수
     }
 }

--- a/src/main/java/com/umc/finly/domain/record/service/FragmentService.java
+++ b/src/main/java/com/umc/finly/domain/record/service/FragmentService.java
@@ -1,5 +1,6 @@
 package com.umc.finly.domain.record.service;
 
+import com.umc.finly.domain.record.dto.res.FragmentCalendarResDTO;
 import com.umc.finly.domain.record.dto.res.FragmentListResDTO;
 import com.umc.finly.domain.record.dto.res.FragmentSummaryResDTO;
 import com.umc.finly.domain.record.enums.EmotionCode;
@@ -15,4 +16,8 @@ public interface FragmentService {
 
     // 조각 모음함 리스트 조회 (감정/기간 필터링 가능)
     FragmentListResDTO getFragmentList(Long memberId, EmotionCode boxType, FragmentPeriodKey periodKey);
+
+    // 기록 홈 캘린더용 날짜별 조각 집계 조회 (yyyy-MM 기준)
+    FragmentCalendarResDTO getFragmentCalendar(Long memberId, String yearMonth);
+
 }

--- a/src/main/java/com/umc/finly/domain/record/service/FragmentServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/record/service/FragmentServiceImpl.java
@@ -1,6 +1,7 @@
 package com.umc.finly.domain.record.service;
 
 import com.umc.finly.domain.record.converter.FragmentConverter;
+import com.umc.finly.domain.record.dto.res.FragmentCalendarResDTO;
 import com.umc.finly.domain.record.dto.res.FragmentListResDTO;
 import com.umc.finly.domain.record.dto.res.FragmentSummaryResDTO;
 import com.umc.finly.domain.record.enums.EmotionCode;
@@ -13,6 +14,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -119,6 +122,86 @@ public class FragmentServiceImpl implements FragmentService {
         return fragmentConverter.toFragmentListRes(
                 boxType, key, from, to, totalCount, rows
         );
+    }
+
+    @Override
+    public FragmentCalendarResDTO getFragmentCalendar(Long memberId, String yearMonth) {
+        // memberId가 없으면 요청 자체가 유효하지 않음
+        if (memberId == null) {
+            throw new CustomException(RecordErrorCode.RECORD_INVALID_REQUEST);
+        }
+
+        // yearMonth가 없으면 서버 기준 현재 월로 처리
+        final YearMonth ym;
+        try {
+            // 프론트에서 "2026-02" 형태로 넘겨주는 값 파싱
+            ym = (yearMonth == null || yearMonth.isBlank())
+                    ? YearMonth.now()
+                    : YearMonth.parse(yearMonth);
+        } catch (DateTimeParseException e) {
+            // yyyy-MM 형식이 아니면 400 처리
+            throw new CustomException(RecordErrorCode.RECORD_INVALID_REQUEST);
+        }
+
+        // 조회 범위 계산 (해당 월의 1일 ~ 말일)
+        LocalDate from = ym.atDay(1);
+        LocalDate to = ym.atEndOfMonth();
+
+        // 날짜별/감정별 집계 조회
+        List<FragmentRepository.CalendarCountProjection> projections =
+                fragmentRepository.countCalendarByDateAndEmotion(memberId, from, to);
+
+        // date -> (type -> count) 집계 맵 구성
+        java.util.Map<LocalDate, java.util.Map<EmotionCode, Long>> byDate = new java.util.LinkedHashMap<>();
+        for (FragmentRepository.CalendarCountProjection p : projections) {
+            LocalDate date = p.getRecordDate();
+            EmotionCode type = p.getEmotionCode();
+            long count = (p.getCount() == null) ? 0L : p.getCount();
+
+            byDate.computeIfAbsent(date, d -> new java.util.EnumMap<>(EmotionCode.class));
+            byDate.get(date).put(type, count);
+        }
+
+        // 응답 days 리스트 구성 (기록이 있는 날짜만 포함)
+        List<FragmentCalendarResDTO.Day> days = new ArrayList<>();
+        for (java.util.Map.Entry<LocalDate, java.util.Map<EmotionCode, Long>> entry : byDate.entrySet()) {
+            LocalDate date = entry.getKey();
+            java.util.Map<EmotionCode, Long> typeMap = entry.getValue();
+
+            // totalCount 계산
+            long totalCount = 0L;
+            for (Long c : typeMap.values()) {
+                totalCount += (c == null) ? 0L : c;
+            }
+
+            // byType 리스트 구성
+            List<FragmentCalendarResDTO.TypeCount> byType = typeMap.entrySet().stream()
+                    .map(e -> FragmentCalendarResDTO.TypeCount.builder()
+                            .type(e.getKey())
+                            .count(e.getValue() == null ? 0L : e.getValue())
+                            .build())
+                    // 안정적인 정렬: count 내림차순, 같으면 type 이름 오름차순
+                    .sorted((a, b) -> {
+                        int cmp = Long.compare(b.getCount(), a.getCount());
+                        if (cmp != 0) return cmp;
+                        String at = (a.getType() == null) ? "" : a.getType().name();
+                        String bt = (b.getType() == null) ? "" : b.getType().name();
+                        return at.compareTo(bt);
+                    })
+                    .toList();
+
+            days.add(FragmentCalendarResDTO.Day.builder()
+                    .date(date)
+                    .totalCount(totalCount)
+                    .byType(byType)
+                    .build());
+        }
+
+        // 총 개수 조회
+        long totalCount = fragmentRepository.countByMemberIdAndRecordDateBetween(memberId, from, to);
+
+        // 최종 응답 조립은 Converter에 위임
+        return fragmentConverter.toCalendarFragment(ym.toString(), from, to, totalCount, days);
     }
 
     // 퍼센트 합이 100이 되도록 보정하는 메서드


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #174 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 기록 홈 메인 화면의 월 캘린더에서 날짜별 조각 현황을 조회하기 위한 API 구현

- 선택된 년/월(yearMonth) 기준으로 조회 범위를 계산하여 날짜별 기록 데이터 제공

- 날짜별 전체 기록 개수 및 감정 타입별 기록 개수 집계 로직 구현

- 기록이 존재하는 날짜만 응답에 포함하여 캘린더 UI 렌더링 최적화

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
* 현재 더미 데이터에 2월 기록만 들어가 있음
- 2026-01
<img width="1182" height="1115" alt="image" src="https://github.com/user-attachments/assets/b3cc8500-e700-4e2d-ba5d-78914e49c815" />

- 2026-02
<img width="1209" height="1302" alt="image" src="https://github.com/user-attachments/assets/804be69d-78f5-42fa-9c17-b3fd78ebdb4f" />

- yeatMonth 미전달 시, 서버 기준 현재 월 데이터 조회
<img width="1221" height="570" alt="image" src="https://github.com/user-attachments/assets/fe61a827-53ca-43be-8898-f7fae0c48b94" />
<img width="1189" height="433" alt="image" src="https://github.com/user-attachments/assets/5ded893e-e4dc-46fa-93b1-9a4b95c0d866" />



`API 응답 예시`
```JSON
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "요청에 성공했습니다.",
  "result": {
    "yearMonth": "2026-02",
    "range": {
      "from": "2026-02-01",
      "to": "2026-02-28"
    },
    "totalRecords": 42,
    "days": [
      {
        "date": "2026-02-01",
        "totalCount": 6,
        "byType": [
          {
            "type": "ANXIETY",
            "count": 2
          },
          {
            "type": "CALM",
            "count": 2
          },
          {
            "type": "CONFIDENCE",
            "count": 1
          },
          {
            "type": "REGRET",
            "count": 1
          }
        ]
      },
      {
        "date": "2026-02-02",
        "totalCount": 4,
        "byType": [
          {
            "type": "ANXIETY",
            "count": 1
          },
          {
            "type": "CONFIDENCE",
            "count": 1
          },
          {
            "type": "GREED",
            "count": 1
          },
          {
            "type": "REGRET",
            "count": 1
          }
        ]
      },
      {
        "date": "2026-02-03",
        "totalCount": 5,
        "byType": [
          {
            "type": "ANXIETY",
            "count": 1
          },
          {
            "type": "CALM",
            "count": 1
          },
          {
            "type": "CONFIDENCE",
            "count": 1
          },
          {
            "type": "GREED",
            "count": 1
          },
          {
            "type": "REGRET",
            "count": 1
          }
        ]
      },
      {
        "date": "2026-02-04",
        "totalCount": 6,
        "byType": [
          {
            "type": "ANXIETY",
            "count": 2
          },
          {
            "type": "CONFIDENCE",
            "count": 2
          },
          {
            "type": "GREED",
            "count": 1
          },
          {
            "type": "REGRET",
            "count": 1
          }
        ]
      },
      {
        "date": "2026-02-05",
        "totalCount": 6,
        "byType": [
          {
            "type": "CONFIDENCE",
            "count": 2
          },
          {
            "type": "ANXIETY",
            "count": 1
          },
          {
            "type": "CALM",
            "count": 1
          },
          {
            "type": "GREED",
            "count": 1
          },
          {
            "type": "REGRET",
            "count": 1
          }
        ]
      },
      {
        "date": "2026-02-06",
        "totalCount": 7,
        "byType": [
          {
            "type": "CONFIDENCE",
            "count": 3
          },
          {
            "type": "REGRET",
            "count": 2
          },
          {
            "type": "ANXIETY",
            "count": 1
          },
          {
            "type": "GREED",
            "count": 1
          }
        ]
      },
      {
        "date": "2026-02-07",
        "totalCount": 8,
        "byType": [
          {
            "type": "CONFIDENCE",
            "count": 4
          },
          {
            "type": "ANXIETY",
            "count": 2
          },
          {
            "type": "CALM",
            "count": 1
          },
          {
            "type": "REGRET",
            "count": 1
          }
        ]
      }
    ]
  }
}
```

## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.
- 캘린더 API는 날짜별 기록 존재 여부 및 개수 표시 용도로 사용
- 날짜 클릭 시 상세 기록 조회는 별도 API에서 처리
- 응답 데이터는 프론트 캘린더 렌더링에 맞춰 기록이 있는 날짜만 반환하도록 설계

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 기록 캘린더 조회 기능 추가 — 연월(yyyy-MM) 기준으로 월별 캘린더 형태로 기록을 확인할 수 있습니다.
  * 일별 총계 및 감정 유형별 집계 제공, 연월 미지정 시 현재 월 기준 조회.
  * 개인 계정의 기록을 기반으로 한 조회(로그인 필요).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->