### PR TITLE
[Hotfix] 마켓 인사이트 오류 수정

### DIFF
--- a/src/main/java/com/umc/finly/domain/market/repository/MarketInsightRepository.java
+++ b/src/main/java/com/umc/finly/domain/market/repository/MarketInsightRepository.java
@@ -11,19 +11,23 @@ import java.util.List;
 
 public interface MarketInsightRepository extends JpaRepository<RecordEntry, Long> {
 
-    @Query("""
-        SELECT r.stockId           AS stockId,
-               s.name              AS stockName,
-               r.emotionCode       AS emotionCode,
-               COUNT(r.id)         AS buyCount
-        FROM RecordEntry r
-        JOIN Stock s ON r.stockId = s.id
-        WHERE r.tradeAction = com.umc.finly.domain.record.enums.TradeAction.BUY
-          AND r.recordDate >= :fromDate
-          AND r.deletedAt IS NULL
-          AND s.isActive = true
-        GROUP BY r.stockId, s.name, r.emotionCode
-    """)// 최근 N일 동안 유저들이 매수(BUY)할 때 느낀 감정을
+    @Query(
+            value = """
+            SELECT
+                r.stock_id      AS stockId,
+                s.name          AS stockName,
+                r.emotion_code  AS emotionCode,
+                COUNT(r.id)     AS buyCount
+            FROM record_entry r
+            JOIN stock s ON r.stock_id = s.id
+            WHERE r.trade_action = 'BUY'
+              AND r.record_date >= :fromDate
+              AND r.deleted_at IS NULL
+              AND s.is_active = true
+            GROUP BY r.stock_id, s.name, r.emotion_code
+        """,
+            nativeQuery = true
+    )// 최근 N일 동안 유저들이 매수(BUY)할 때 느낀 감정을
 // 종목 이름 기준으로 집계하여 실시간 인사이트 생성을 위한 쿼리
 
     List<StockEmotionBuyAggregation> aggregateBuyEmotionByStock(

--- a/src/main/java/com/umc/finly/domain/market/service/MarketInsightService.java
+++ b/src/main/java/com/umc/finly/domain/market/service/MarketInsightService.java
@@ -57,7 +57,7 @@ public class MarketInsightService {
                 candidates.get(new Random().nextInt(candidates.size()));
 
         String stockName = picked.getStockName();
-        EmotionCode emotion = EmotionCode.valueOf(picked.getEmotionCode());// 감정 enum 받아오기
+        EmotionCode emotion = parseEmotion(picked.getEmotionCode());
 
         String message = generateMessage(stockName, emotion);
 
@@ -68,6 +68,19 @@ public class MarketInsightService {
                 .buySellRatio("BUY_DOMINANT")
                 .confidenceLevel(calcConfidence(candidates.size()))
                 .build();
+    }
+
+    private EmotionCode parseEmotion(String emotionCode) {
+        if (emotionCode == null || emotionCode.isBlank()) {
+            return EmotionCode.CALM;
+        }
+
+        try {
+            return EmotionCode.valueOf(emotionCode);
+        } catch (IllegalArgumentException e) {
+            // enum에 없는 값은 기본값으로 처리
+            return EmotionCode.CALM;
+        }
     }
 
     //문장 생성하기 (사용자가 구매한 종목명 표시하기  )


### PR DESCRIPTION
## 🔗 관련 이슈
> #176 

closes #176

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

마켓 인사이트 조회 시 No enum constant EmotionCode 오류로 500 에러가 발생하던 문제를 수정했습니다.

원인은 JPQL에서 RecordEntry.emotionCode(enum 필드)를 직접 조회하면서,
DB에 enum과 불일치한 값이 존재할 경우 Hibernate가 쿼리 실행 단계에서 예외를 발생시키던 구조였습니다.

이를 해결하기 위해 JPQL을 native query로 변경하고,
emotion_code 컬럼을 문자열(String)로 직접 조회하도록 수정했습니다.

조회 결과는 기존 StockEmotionBuyAggregation projection을 그대로 사용하여
Service 레벨에서 안전하게 enum 변환(parseEmotion)이 이루어지도록 했습니다

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="918" height="474" alt="image" src="https://github.com/user-attachments/assets/4dfc42b8-9733-4143-82ca-76289fc28b40" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 유효하지 않거나 누락된 감정 데이터를 안정적으로 처리하도록 개선했습니다.

* **성능 최적화**
  * 주식별 감정 데이터 조회 성능을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->