### PR TITLE
[Hotfix] 금융 마음 지수 쿼리문 수정 ( 2개 조회 안되도록)

### DIFF
--- a/src/main/java/com/umc/finly/domain/home/repository/HomeMindRepository.java
+++ b/src/main/java/com/umc/finly/domain/home/repository/HomeMindRepository.java
@@ -29,24 +29,22 @@ public interface HomeMindRepository extends Repository<RecordEntry, Long> {
             LocalDate end
     );
 
-
-    //A. 하락장 공포지수 (최신)
+    // A. 하락장 공포지수 (최신 1개)
     @Query("""
         select f
         from FearIndexResult f
         where f.memberId = :memberId
         order by f.endDate desc
     """)
-    Optional<FearIndexResult> findLatestFearIndexResult(Long memberId);
+    List<FearIndexResult> findLatestFearIndexResults(Long memberId);
 
-
-    //B. 매수 확신도 (최신)
+    // B. 매수 확신도 (최신 1개)
     @Query("""
         select c
         from ConvictionScoreResult c
         where c.memberId = :memberId
         order by c.endDate desc
     """)
-    Optional<ConvictionScoreResult> findLatestConvictionScoreResult(Long memberId);
+    List<ConvictionScoreResult> findLatestConvictionScoreResults(Long memberId);
 
 }

--- a/src/main/java/com/umc/finly/domain/home/service/HomeMindServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/home/service/HomeMindServiceImpl.java
@@ -1,5 +1,7 @@
 package com.umc.finly.domain.home.service;
 
+import com.umc.finly.domain.analysis.association.entity.ConvictionScoreResult;
+import com.umc.finly.domain.analysis.association.entity.FearIndexResult;
 import com.umc.finly.domain.home.dto.res.HomeMindDetailResDTO;
 import com.umc.finly.domain.home.dto.res.HomeMindResDTO;
 import com.umc.finly.domain.home.exception.code.HomeErrorCode;
@@ -51,17 +53,20 @@ public class HomeMindServiceImpl implements HomeMindService {
           int cScore = (int) ((double) recordedDays / now.lengthOfMonth() * 100);
 
           /* ========= A. 하락장 회복탄력성 ========= */
-          int aScore = homeMindRepository
-                  .findLatestFearIndexResult(memberId)
-                  // 공포지수 ↑ = 회복탄력성 ↓
-                  .map(r -> Math.max(0, 100 - r.getFearIndex().intValue()))
-                  .orElse(0);
+          List<FearIndexResult> fearResults =
+                  homeMindRepository.findLatestFearIndexResults(memberId);
+
+          int aScore = fearResults.isEmpty()
+                  ? 0
+                  : Math.max(0, 100 - fearResults.get(0).getFearIndex().intValue());
 
           /* ========= B. 매수 확신도 ========= */
-          int bScore = homeMindRepository
-                  .findLatestConvictionScoreResult(memberId)
-                  .map(r -> r.getConvictionScore().intValue())
-                  .orElse(0);
+          List<ConvictionScoreResult> convictionResults =
+                  homeMindRepository.findLatestConvictionScoreResults(memberId);
+
+          int bScore = convictionResults.isEmpty()
+                  ? 0
+                  : convictionResults.get(0).getConvictionScore().intValue();
 
           int fmi = (int) (
                   aScore * 0.4 +


### PR DESCRIPTION
## 🔗 관련 이슈
> #181 

closes #181

## 📌 작업 내용
> 
최신 데이터를 보장하기 위해
order by endDate desc + List 조회 후 Service에서 첫 번째 값 사용 방식으로 변경

Query did not return a unique result 오류 원인 제거


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.
<img width="902" height="496" alt="image" src="https://github.com/user-attachments/assets/6bb23e8e-2411-45b3-9549-f9b4146b83da" />



## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 공포지수와 신념점수 데이터 처리 로직을 개선하여 더 안정적인 결과 처리를 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->