### PR TITLE
[Refactor] 조각 모음함 요약 조회 API 응답 구조 변경

### DIFF
--- a/src/main/java/com/umc/finly/domain/record/converter/FragmentConverter.java
+++ b/src/main/java/com/umc/finly/domain/record/converter/FragmentConverter.java
@@ -24,16 +24,16 @@ public class FragmentConverter {
     public FragmentSummaryResDTO toFragmentSummaryRes(
             long totalCount,
             EmotionCode dominantType,
-            boolean isMultipleDominant,
+            boolean multipleDominant,
             EmotionCode recessiveType,
-            boolean isMultipleRecessive,
+            boolean multipleRecessive,
             List<FragmentSummaryResDTO.TypeSummary> summaries) {
         return FragmentSummaryResDTO.builder()
                 .totalCount((int) totalCount)
                 .dominantType(dominantType)
-                .isMultipleDominant(isMultipleDominant)
+                .multipleDominant(multipleDominant)
                 .recessiveType(recessiveType)
-                .isMultipleRecessive(isMultipleRecessive)
+                .multipleRecessive(multipleRecessive)
                 .typeSummary(summaries)
                 .build();
     }

--- a/src/main/java/com/umc/finly/domain/record/converter/FragmentConverter.java
+++ b/src/main/java/com/umc/finly/domain/record/converter/FragmentConverter.java
@@ -24,10 +24,16 @@ public class FragmentConverter {
     public FragmentSummaryResDTO toFragmentSummaryRes(
             long totalCount,
             EmotionCode dominantType,
+            boolean isMultipleDominant,
+            EmotionCode recessiveType,
+            boolean isMultipleRecessive,
             List<FragmentSummaryResDTO.TypeSummary> summaries) {
         return FragmentSummaryResDTO.builder()
                 .totalCount((int) totalCount)
                 .dominantType(dominantType)
+                .isMultipleDominant(isMultipleDominant)
+                .recessiveType(recessiveType)
+                .isMultipleRecessive(isMultipleRecessive)
                 .typeSummary(summaries)
                 .build();
     }

--- a/src/main/java/com/umc/finly/domain/record/dto/res/FragmentSummaryResDTO.java
+++ b/src/main/java/com/umc/finly/domain/record/dto/res/FragmentSummaryResDTO.java
@@ -1,5 +1,6 @@
 package com.umc.finly.domain.record.dto.res;
 
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.umc.finly.domain.record.enums.EmotionCode;
 import lombok.*;
 
@@ -11,10 +12,21 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonPropertyOrder({
+        "totalCount",
+        "dominantType",
+        "isMultipleDominant",
+        "recessiveType",
+        "isMultipleRecessive",
+        "typeSummary"
+})
 public class FragmentSummaryResDTO {
 
     private int totalCount;                   // 전체 기록 개수
-    private EmotionCode dominantType;         // 가장 많이 기록된 감정 타입 (우세 감정)
+    private EmotionCode dominantType;         // 가장 많이 기록된 감정 타입 (동률 시 최신순)
+    private boolean isMultipleDominant;       // 가장 많은 조각이 여러 개인지 여부
+    private EmotionCode recessiveType;        // 가장 적은 조각 (동률 시 최신순)
+    private boolean isMultipleRecessive;      // 가장 적은 조각이 여러 개인지 여부
     private List<TypeSummary> typeSummary;    // 감정 타입별 요약 정보 리스트
 
     // 감정 타입별 통계

--- a/src/main/java/com/umc/finly/domain/record/dto/res/FragmentSummaryResDTO.java
+++ b/src/main/java/com/umc/finly/domain/record/dto/res/FragmentSummaryResDTO.java
@@ -15,18 +15,18 @@ import java.util.List;
 @JsonPropertyOrder({
         "totalCount",
         "dominantType",
-        "isMultipleDominant",
+        "multipleDominant",
         "recessiveType",
-        "isMultipleRecessive",
+        "multipleRecessive",
         "typeSummary"
 })
 public class FragmentSummaryResDTO {
 
     private int totalCount;                   // 전체 기록 개수
     private EmotionCode dominantType;         // 가장 많이 기록된 감정 타입 (동률 시 최신순)
-    private boolean isMultipleDominant;       // 가장 많은 조각이 여러 개인지 여부
+    private boolean multipleDominant;       // 가장 많은 조각이 여러 개인지 여부
     private EmotionCode recessiveType;        // 가장 적은 조각 (동률 시 최신순)
-    private boolean isMultipleRecessive;      // 가장 적은 조각이 여러 개인지 여부
+    private boolean multipleRecessive;      // 가장 적은 조각이 여러 개인지 여부
     private List<TypeSummary> typeSummary;    // 감정 타입별 요약 정보 리스트
 
     // 감정 타입별 통계

--- a/src/main/java/com/umc/finly/domain/record/enums/EmotionCode.java
+++ b/src/main/java/com/umc/finly/domain/record/enums/EmotionCode.java
@@ -9,11 +9,11 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum EmotionCode {
-    CALM("평온", "으로"),       // 평온 - 차분하고 안정된 상태
     ANXIETY("불안", "으로"),    // 불안 - 걱정, 초조한 상태
-    REGRET("후회", "로"),       // 후회 - 매매 결정에 대한 아쉬움
     GREED("탐욕", "으로"),      // 탐욕 - 더 많은 수익을 원하는 상태
-    CONFIDENCE("확신", "으로"); // 확신 - 매매 결정에 대한 강한 믿음
+    CALM("평온", "으로"),       // 평온 - 차분하고 안정된 상태
+    CONFIDENCE("확신", "으로"), // 확신 - 매매 결정에 대한 강한 믿음
+    REGRET("후회", "로");       // 후회 - 매매 결정에 대한 아쉬움
 
     private final String label;    // 한글 표기명
     private final String particle; // 조사 (문장 생성용)

--- a/src/main/java/com/umc/finly/domain/record/repository/FragmentRepository.java
+++ b/src/main/java/com/umc/finly/domain/record/repository/FragmentRepository.java
@@ -21,10 +21,13 @@ public interface FragmentRepository extends JpaRepository<RecordEntry, Long> {
 
     // 감정 타입별 기록 개수 집계 (조각 모음함 요약용)
     @Query("""
-        select r.emotionCode as emotionCode, count(r) as count
-        from RecordEntry r
-        where r.memberId = :memberId
-        group by r.emotionCode
+    select
+        r.emotionCode as emotionCode,
+        count(r) as count,
+        max(r.createdAt) as latestAt
+    from RecordEntry r
+    where r.memberId = :memberId
+    group by r.emotionCode
     """)
     List<EmotionCountProjection> countGroupByEmotionCode(@Param("memberId") Long memberId);
 
@@ -108,8 +111,9 @@ public interface FragmentRepository extends JpaRepository<RecordEntry, Long> {
 
     // 감정별 개수 집계 결과를 받기 위한 Projection
     interface EmotionCountProjection {
-        EmotionCode getEmotionCode(); // 감정 코드
-        Long getCount();              // 해당 감정의 기록 개수
+        EmotionCode getEmotionCode();           // 감정 코드
+        Long getCount();                        // 해당 감정의 기록 개수
+        java.time.LocalDateTime getLatestAt();  // 해당 감정의 최신 기록 시각
     }
 
     // 조각 리스트 조회 결과를 담는 Projection (Stock 조인 포함)

--- a/src/main/java/com/umc/finly/domain/record/service/FragmentServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/record/service/FragmentServiceImpl.java
@@ -92,8 +92,16 @@ public class FragmentServiceImpl implements FragmentService {
         // 퍼센트 합이 100이 되도록 보정 (반올림 오차 수정)
         adjustPercentTo100(summaries);
 
-        // count 기준 내림차순 정렬
-        summaries.sort((a, b) -> Long.compare(b.getCount(), a.getCount()));
+        // count 기준 내림차순 정렬 + 동률 시 한글 라벨 ㄱㄴㄷ순
+        summaries.sort((a, b) -> {
+            int cmp = Long.compare(b.getCount(), a.getCount()); // 내림차순
+            if (cmp != 0) return cmp;
+
+            // 동률 시 한글 라벨 ㄱㄴㄷ순 정렬
+            String al = (a.getType() == null) ? "" : a.getType().getLabel();
+            String bl = (b.getType() == null) ? "" : b.getType().getLabel();
+            return al.compareTo(bl);
+        });
 
         // 집계 데이터가 없으면(이론상 total>0이면 없기 어렵지만) 방어
         if (aggs.isEmpty()) {
@@ -118,7 +126,7 @@ public class FragmentServiceImpl implements FragmentService {
         // recessive 비교 기준: count asc, 동률이면 latestAt desc
         // min으로 뽑을 거라 "동률이면 최신이 선택"되게 latestAt을 반대로(내림차순) 넣어줌
         java.util.Comparator<EmotionAgg> recessiveComparator = (a, b) -> {
-            int cmp = Long.compare(a.count, b.count); // // count 오름차순
+            int cmp = Long.compare(a.count, b.count); // count 오름차순
             if (cmp != 0) return cmp;
             // 동률이면 최신이 앞으로 오도록 (내림차순)
             return compareLatestDesc(a.latestAt, b.latestAt);
@@ -239,12 +247,12 @@ public class FragmentServiceImpl implements FragmentService {
                             .type(e.getKey())
                             .count(e.getValue() == null ? 0L : e.getValue())
                             .build())
-                    // 안정적인 정렬: count 내림차순, 같으면 type 이름 오름차순
+                    // 안정적인 정렬: count 내림차순, 같으면 감정 한글 라벨 기준 ㄱㄴㄷ 정렬
                     .sorted((a, b) -> {
                         int cmp = Long.compare(b.getCount(), a.getCount());
                         if (cmp != 0) return cmp;
-                        String at = (a.getType() == null) ? "" : a.getType().name();
-                        String bt = (b.getType() == null) ? "" : b.getType().name();
+                        String at = (a.getType() == null) ? "" : a.getType().getLabel();
+                        String bt = (b.getType() == null) ? "" : b.getType().getLabel();
                         return at.compareTo(bt);
                     })
                     .toList();
@@ -304,7 +312,7 @@ public class FragmentServiceImpl implements FragmentService {
         }
     }
 
-    // /dominant/recessive 산출을 위한 내부 집계 모델
+    // dominant/recessive 산출을 위한 내부 집계 모델
     private static class EmotionAgg {
         private final EmotionCode type;
         private final long count;

--- a/src/main/java/com/umc/finly/domain/record/service/FragmentServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/record/service/FragmentServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -44,6 +45,9 @@ public class FragmentServiceImpl implements FragmentService {
             return fragmentConverter.toFragmentSummaryRes(
                     0L,
                     null,
+                    false,
+                    null,
+                    false,
                     Collections.emptyList()
             );
         }
@@ -52,13 +56,14 @@ public class FragmentServiceImpl implements FragmentService {
         List<FragmentRepository.EmotionCountProjection> projections =
                 fragmentRepository.countGroupByEmotionCode(memberId);
 
-        // 가장 많은 감정(dominantType) 계산
-        EmotionCode dominantType = null;
-        long maxCount = -1;
-
+        // 파이차트용 summaries 구성
         List<FragmentSummaryResDTO.TypeSummary> summaries = new ArrayList<>();
 
+        // dominant/recessive 산출용 집계 리스트
+        List<EmotionAgg> aggs = new ArrayList<>();
+
         for (FragmentRepository.EmotionCountProjection p : projections) {
+            // null 방어
             long count = p.getCount() == null ? 0L : p.getCount();
 
             // count가 0이면 목록에서 제외
@@ -66,20 +71,22 @@ public class FragmentServiceImpl implements FragmentService {
                 continue;
             }
 
-            // 가장 많은 감정 갱신
-            if (dominantType == null || count > maxCount) {
-                dominantType = p.getEmotionCode();
-                maxCount = count;
-            }
-
             // 퍼센트 계산 (반올림)
             int percent = (int) Math.round(count * 100.0 / total);
 
+            // typeSummary용 DTO 구성
             summaries.add(FragmentSummaryResDTO.TypeSummary.builder()
                     .type(p.getEmotionCode())
                     .count(count)
                     .percent(percent)
                     .build());
+
+            // dominant/recessive 판별용 데이터 적재
+            aggs.add(new EmotionAgg(
+                    p.getEmotionCode(),
+                    count,
+                    p.getLatestAt()            
+            ));
         }
 
         // 퍼센트 합이 100이 되도록 보정 (반올림 오차 수정)
@@ -88,7 +95,59 @@ public class FragmentServiceImpl implements FragmentService {
         // count 기준 내림차순 정렬
         summaries.sort((a, b) -> Long.compare(b.getCount(), a.getCount()));
 
-        return fragmentConverter.toFragmentSummaryRes(total, dominantType, summaries);
+        // 집계 데이터가 없으면(이론상 total>0이면 없기 어렵지만) 방어
+        if (aggs.isEmpty()) {
+            return fragmentConverter.toFragmentSummaryRes(
+                    total,
+                    null,
+                    false,
+                    null,
+                    false,
+                    summaries
+            );
+        }
+
+        // dominant 비교 기준: count desc, 동률이면 latestAt desc
+        java.util.Comparator<EmotionAgg> dominantComparator = (a, b) -> {
+            int cmp = Long.compare(a.count, b.count); // 기본은 count 오름차순
+            if (cmp != 0) return cmp;
+            // 동률이면 최신시각 오름차순(뒤가 최신) -> max로 뽑을 거라 최신이 선택됨
+            return compareLatestAsc(a.latestAt, b.latestAt);
+        };
+
+        // recessive 비교 기준: count asc, 동률이면 latestAt desc
+        // min으로 뽑을 거라 "동률이면 최신이 선택"되게 latestAt을 반대로(내림차순) 넣어줌
+        java.util.Comparator<EmotionAgg> recessiveComparator = (a, b) -> {
+            int cmp = Long.compare(a.count, b.count); // // count 오름차순
+            if (cmp != 0) return cmp;
+            // 동률이면 최신이 앞으로 오도록 (내림차순)
+            return compareLatestDesc(a.latestAt, b.latestAt);
+        };
+
+        // dominantType 산출 (max)
+        EmotionAgg dominantAgg = Collections.max(aggs, dominantComparator);
+        EmotionCode dominantType = dominantAgg.type;
+
+        // recessiveType 산출 (min)
+        EmotionAgg recessiveAgg = Collections.min(aggs, recessiveComparator);
+        EmotionCode recessiveType = recessiveAgg.type;
+
+        // 동률 여부 계산 (max/min count 기준)
+        long maxCount = aggs.stream().mapToLong(a -> a.count).max().orElse(0L);
+        long minCount = aggs.stream().mapToLong(a -> a.count).min().orElse(0L);
+
+        boolean isMultipleDominant = aggs.stream().filter(a -> a.count == maxCount).count() >= 2;
+        boolean isMultipleRecessive = aggs.stream().filter(a -> a.count == minCount).count() >= 2;
+
+        // DTO 응답 변환
+        return fragmentConverter.toFragmentSummaryRes(
+                total,
+                dominantType,
+                isMultipleDominant,
+                recessiveType,
+                isMultipleRecessive,
+                summaries
+        );
     }
 
     @Override
@@ -243,5 +302,40 @@ public class FragmentServiceImpl implements FragmentService {
                 attempts++;
             }
         }
+    }
+
+    // /dominant/recessive 산출을 위한 내부 집계 모델
+    private static class EmotionAgg {
+        private final EmotionCode type;
+        private final long count;
+        private final LocalDateTime latestAt;
+
+        private EmotionAgg(EmotionCode type, long count, LocalDateTime latestAt) {
+            this.type = type;
+            this.count = count;
+            this.latestAt = latestAt;
+        }
+    }
+
+    // latestAt 오름차순 비교(null 안전) - max에서 최신이 선택되도록 사용
+    private int compareLatestAsc(LocalDateTime a, LocalDateTime b) {
+        // 둘 다 null이면 동일
+        if (a == null && b == null) return 0;
+        // null은 뒤로
+        if (a == null) return 1;
+        if (b == null) return -1;
+        // 오래된 게 앞으로
+        return a.compareTo(b);
+    }
+
+    // latestAt 내림차순 비교(null 안전)
+    private int compareLatestDesc(LocalDateTime a, LocalDateTime b) {
+        // 둘 다 null이면 동일
+        if (a == null && b == null) return 0;
+        // null은 뒤로
+        if (a == null) return 1;
+        if (b == null) return -1;
+        // 최신이 앞으로
+        return b.compareTo(a);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #202 

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- 조각 모음함 요약 조회 API 응답 구조 확장
  - 가장 많은 감정(`dominantType`) 추가
  - 가장 적은 감정(`recessiveType`) 추가
  - 동률 여부 플래그(`isMultipleDominant`, `isMultipleRecessive`) 추가
- 감정별 요약(`typeSummary`)은 기존 구조 유지

### 정렬/결정 규칙(현재 구현 기준)
- `typeSummary` 정렬:
  - 1차: `count` 내림차순
  - 2차(동률): `EmotionCode.label` 한글 라벨 기준 ㄱㄴㄷ 오름차순
- `dominantType` 결정:
  - 1차: `count` 기준 최댓값
  - 2차(동률): `latestAt`(= max(createdAt)) 최신순
- `recessiveType` 결정:
  - 1차: `count` 기준 최솟값
  - 2차(동률): `latestAt`(= max(createdAt)) 최신순
- 캘린더 `byType` 정렬:
  - 1차: `count` 내림차순
  - 2차(동률): `EmotionCode.label` 한글 라벨 기준 ㄱㄴㄷ 오름차순

※ 참고: `dominantType/recessiveType`는 count 및 latestAt까지 동률인 경우에 대한 추가 tie-breaker는 두지 않았습니다(발생 가능성이 낮고, 현재 요구 화면에서 영향도가 낮다고 판단).

## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

`API 응답`

``` JSON
{
  "isSuccess": true,
  "code": "COMMON200",
  "message": "요청에 성공했습니다.",
  "result": {
    "totalCount": 42,
    "dominantType": "CONFIDENCE",
    "recessiveType": "CALM",
    "typeSummary": [
      {
        "type": "CONFIDENCE",
        "count": 14,
        "percent": 33
      },
      {
        "type": "ANXIETY",
        "count": 10,
        "percent": 24
      },
      {
        "type": "REGRET",
        "count": 8,
        "percent": 19
      },
      {
        "type": "GREED",
        "count": 5,
        "percent": 12
      },
      {
        "type": "CALM",
        "count": 5,
        "percent": 12
      }
    ],
    "multipleDominant": false,
    "multipleRecessive": true
  }
}
```

- CALM created_at 
<img width="601" height="194" alt="image" src="https://github.com/user-attachments/assets/742e8b62-c099-447e-b826-a511564104d0" />

- GREED created_at
<img width="606" height="205" alt="image" src="https://github.com/user-attachments/assets/adbaad59-9bfe-473c-bada-bf4df6e7939c" />

- 동률 시, ㄱㄴㄷ 순 정렬
<img width="210" height="206" alt="image" src="https://github.com/user-attachments/assets/ccb2d203-077b-43f0-913a-a7ebe09abf70" />


## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 감정 분석 응답에 다수 우세/다수 열성 표시 필드 추가(multipleDominant, multipleRecessive, recessiveType 포함)
  * 동일 빈도 감정 발생 시 최신 기록 시간을 기준으로 우세/열성 판별 로직 개선
* **버그 수정 / 안정성**
  * 감정 요약 정렬과 동점 처리에서 결정적 결과 보장(동일 빈도 시 레이블 기준 정렬 및 null-safe 시간 비교)
* **API 변경**
  * 응답 직렬화 순서가 명시적으로 지정되어 일관성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->