### PR TITLE
[Hotfix] ConvictionScore, FearIndex 결과 없을 때 에러 대신 기본값으로 변경

### DIFF
--- a/src/main/java/com/umc/finly/domain/analysis/association/service/ConvictionScoreServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/service/ConvictionScoreServiceImpl.java
@@ -3,6 +3,7 @@ package com.umc.finly.domain.analysis.association.service;
 import com.umc.finly.domain.analysis.association.converter.ConvictionScoreConverter;
 import com.umc.finly.domain.analysis.association.dto.response.ConvictionScoreResDTO;
 import com.umc.finly.domain.analysis.association.entity.ConvictionScoreResult;
+import com.umc.finly.domain.analysis.association.enums.Status;
 import com.umc.finly.domain.analysis.association.exception.code.ConvictionScoreErrorCode;
 import com.umc.finly.domain.analysis.association.exception.ConvictionScoreException;
 import com.umc.finly.domain.analysis.association.repository.ConvictionScoreResultRepository;
@@ -29,10 +30,16 @@ public class ConvictionScoreServiceImpl implements ConvictionScoreService {
     @Override
     public ConvictionScoreResDTO getConvictionScore(Long memberId) {
         // 가장 최신 매수 확신도 결과 조회
-        ConvictionScoreResult currentResult = convictionScoreResultRepository.findFirstByMemberIdOrderByEndDateDesc(memberId)
-                .orElseThrow(() -> new ConvictionScoreException(ConvictionScoreErrorCode.CONVICTION_SCORE_NOT_FOUND));
-
-        return ConvictionScoreConverter.toConvictionScoreResDTO(currentResult.getConvictionScore());
+        return convictionScoreResultRepository.findFirstByMemberIdOrderByEndDateDesc(memberId)
+                .map(currentResult ->
+                        ConvictionScoreConverter.toConvictionScoreResDTO(currentResult.getConvictionScore())
+                )
+                // 결과 데이터가 없을 경우 기본값 반환
+                .orElseGet(() -> ConvictionScoreResDTO.builder()
+                        .convictionScore(0)
+                        .status(Status.LOW)
+                        .phrase("분석을 위해 데이터를 모으는 중이에요")
+                        .build());
     }
 
 }

--- a/src/main/java/com/umc/finly/domain/analysis/association/service/ConvictionScoreServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/service/ConvictionScoreServiceImpl.java
@@ -15,6 +15,7 @@ import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ConvictionScoreServiceImpl implements ConvictionScoreService {
 
     private final ConvictionScoreResultRepository convictionScoreResultRepository;

--- a/src/main/java/com/umc/finly/domain/analysis/association/service/FearIndexServiceImpl.java
+++ b/src/main/java/com/umc/finly/domain/analysis/association/service/FearIndexServiceImpl.java
@@ -3,6 +3,7 @@ package com.umc.finly.domain.analysis.association.service;
 import com.umc.finly.domain.analysis.association.converter.FearIndexConverter;
 import com.umc.finly.domain.analysis.association.dto.response.FearIndexResDTO;
 import com.umc.finly.domain.analysis.association.entity.FearIndexResult;
+import com.umc.finly.domain.analysis.association.enums.ChangeDirection;
 import com.umc.finly.domain.analysis.association.exception.code.FearIndexErrorCode;
 import com.umc.finly.domain.analysis.association.exception.FearIndexException;
 import com.umc.finly.domain.analysis.association.repository.FearIndexResultRepository;
@@ -29,20 +30,24 @@ public class FearIndexServiceImpl implements FearIndexService {
 
     @Override
     public FearIndexResDTO getFearIndex(Long memberId) {
-        // 1. 가장 최근에 저장된 분석 결과 조회
-        FearIndexResult currentResult = fearIndexResultRepository.findFirstByMemberIdOrderByEndDateDesc(memberId)
-                .orElseThrow(() -> new FearIndexException(FearIndexErrorCode.FEAR_INDEX_NOT_FOUND));
+        // 가장 최근 분석 결과 조회
+        return fearIndexResultRepository.findFirstByMemberIdOrderByEndDateDesc(memberId)
+                .map(currentResult -> {
+                    // [결과 데이터가 있는 경우]
+                    // 이전 데이터 조회 로직 진행
+                    int prevScore = fearIndexResultRepository.findFirstByMemberIdAndEndDateBeforeOrderByEndDateDesc(
+                                    memberId, currentResult.getStartDate())
+                            .map(FearIndexResult::getFearIndex)
+                            .orElse(currentResult.getFearIndex());  // 이전 기록 없으면 현재와 동일 처리
 
-        // 2. 해당 결과의 시작일(startDate)을 기준으로 그보다 이전의 마지막 데이터 조회 (변화량 비교용)
-        int prevScore = fearIndexResultRepository.findFirstByMemberIdAndEndDateBeforeOrderByEndDateDesc(
-                        memberId, currentResult.getStartDate())
-                .map(FearIndexResult::getFearIndex)
-                .orElse(currentResult.getFearIndex()); // 이전 기록 없으면 현재와 동일 처리
-
-        // 3. 컨버터를 통해 DTO로 변환하여 반환
-        return FearIndexConverter.toFearIndexResDTO(
-                currentResult.getFearIndex(),
-                prevScore
-        );
+                    return FearIndexConverter.toFearIndexResDTO(currentResult.getFearIndex(), prevScore);
+                })
+                // [결과 데이터가 없는 경우]
+                .orElseGet(() -> FearIndexResDTO.builder()
+                        .fearIndex(0)
+                        .changeDirection(ChangeDirection.SAME)
+                        .changeValue(0)
+                        .phrase("분석을 위해 데이터를 모으는 중이에요")
+                        .build());
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.

closes #

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

기존에는 하락장공포지수, 매수확신도 DB에 저장된 산출 결과값이 없을 경우 에러를 발생시켰지만, 두 지수 모두 산출에 일정 기간이 소요되므로 에러 대신 기본값 내려주는 것으로 변경하였습니다.


## 🧪 테스트 결과
> Postman 스크린샷, 테스트 통과 여부 등을 첨부해주세요.

<img width="1402" height="376" alt="image" src="https://github.com/user-attachments/assets/cd0c8f52-7b94-4069-9edf-b169012ce3c6" />

<img width="1405" height="352" alt="image" src="https://github.com/user-attachments/assets/cc553823-dc39-4549-869e-a5469233f28b" />




## 📸 스크린샷 (선택)
> 필요시 스크린샷을 첨부해주세요.



## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 내용이 있다면 작성해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 신념 점수가 없을 때 더 이상 오류를 발생시키지 않고 기본값을 반환하도록 개선했습니다.
  * 공포 지수 데이터가 없을 때 더 이상 오류를 발생시키지 않고 기본값을 반환하도록 개선했습니다.
  * 관련 응답 처리 로직을 안정화하여 조회 시 일관된 결과를 제공하도록 했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->